### PR TITLE
docs: add Claude Code marketplace installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,20 @@
 # Jarvus Agent Skills
 
-A collection of agent skills used within Jarvus:
+A collection of agent skills used within Jarvus.
+
+## Installation
+
+Install via Claude Code marketplace:
+
+```bash
+# Add the Jarvus marketplace
+/plugin marketplace add JarvusInnovations/agent-skills
+
+# Install the skills plugin
+/plugin install jarvus-skills@jarvus-agent-skills
+```
+
+## Skills
 
 - `frontend-shadcn`: Frontend development using Vite+React+ShadCN+Tailwind
 - `backend-fastify`: Backend development using Node.js+Fastify
-


### PR DESCRIPTION
Add installation instructions to the README showing how to install the plugin via Claude Code marketplace using the marketplace add and plugin install commands.