### PR TITLE
docs: enforce npm install for package management in both skills

### DIFF
--- a/skills/backend-fastify/SKILL.md
+++ b/skills/backend-fastify/SKILL.md
@@ -168,3 +168,4 @@ backend/
 - **Config access**: Use `fastify.config.VAR` not `process.env.VAR`
 - **Server ready**: Call `await server.ready()` before accessing config in index.ts
 - **Path normalization**: Centralize path utilities, handle root '/' as special case
+- **Package management**: Use `npm install <pkg>` not manual `package.json` edits

--- a/skills/backend-fastify/references/patterns.md
+++ b/skills/backend-fastify/references/patterns.md
@@ -403,3 +403,28 @@ await fastify.register(userRoutes, { prefix: '/api/users' })
 await fastify.register(orderRoutes, { prefix: '/api/orders' })
 await fastify.register(healthRoutes, { prefix: '/api/health' })
 ```
+
+## Package Management
+
+Always use npm commands to manage dependencies:
+
+- Always use `npm install <package-name>` to add dependencies
+- Never manually edit `package.json` to add packages
+- This ensures the latest compatible versions are installed and `package-lock.json` stays in sync
+
+### Adding Dependencies
+
+```bash
+# Runtime dependencies
+npm install fastify-plugin @fastify/cors pino
+
+# Development dependencies
+npm install -D @types/node typescript
+```
+
+### Why This Matters
+
+- `npm install` automatically resolves to the latest compatible version
+- Manual edits can introduce version mismatches
+- `package-lock.json` won't be properly updated with manual edits
+- Dependency tree conflicts are harder to debug after manual edits

--- a/skills/frontend-shadcn/SKILL.md
+++ b/skills/frontend-shadcn/SKILL.md
@@ -118,3 +118,9 @@ src/
 "h-screen overflow-auto"            // Full height scrolling
 "space-y-4"                         // Vertical spacing
 ```
+
+### Common Gotchas
+
+- **Package management**: Use `npm install <pkg>` not manual `package.json` edits
+- **shadcn components**: Use `npx shadcn@latest add <component> -y`
+- **React Router imports**: Use `react-router` NOT `react-router-dom`


### PR DESCRIPTION
Enforce npm install usage across frontend-shadcn and backend-fastify skills to ensure current package versions are always installed and package-lock.json stays in sync.

Changes:
- Add Package Management section to backend-fastify patterns.md with examples and rationale
- Add package management reminder to both skills' gotchas sections
- Ensure consistent guidance across all skill documentation

This prevents version mismatches and dependency conflicts from manual package.json edits.