### PR TITLE
Add VSCode debugging configuration to setup guides

### DIFF
--- a/skills/backend-fastify/references/setup-guide.md
+++ b/skills/backend-fastify/references/setup-guide.md
@@ -447,6 +447,54 @@ npm run type-check
 
 ---
 
+## VSCode Debugging
+
+Configure VSCode to debug the backend with breakpoints, variable inspection, and step-through execution.
+
+### Launch Configuration
+
+**Create `.vscode/launch.json`:**
+
+```json
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Debug Backend",
+      "type": "node",
+      "request": "launch",
+      "program": "${workspaceFolder}/backend/src/index.ts",
+      "cwd": "${workspaceFolder}/backend",
+      "runtimeExecutable": "npx",
+      "runtimeArgs": ["tsx"],
+      "envFile": "${workspaceFolder}/backend/.env",
+      "console": "integratedTerminal",
+      "sourceMaps": true,
+      "skipFiles": ["<node_internals>/**", "**/node_modules/**"]
+    }
+  ]
+}
+```
+
+**Key patterns:**
+
+- `runtimeExecutable: "npx"` with `runtimeArgs: ["tsx"]` runs TypeScript directly without pre-compilation
+- `envFile` loads environment variables from `.env` file
+- `sourceMaps: true` enables breakpoints in TypeScript source files
+- `skipFiles` excludes Node internals and dependencies from step-through
+- `console: "integratedTerminal"` shows pino-pretty formatted logs
+
+### Using the Debugger
+
+1. **Set breakpoints** - Click the gutter next to line numbers in any `.ts` file
+2. **Start debugging** - Press `F5` or select "Debug Backend" from the Run and Debug panel
+3. **Debug controls** - Use Continue (F5), Step Over (F10), Step Into (F11), Step Out (Shift+F11)
+4. **Inspect variables** - Hover over variables or use the Variables panel
+
+**Commit:** `config(backend): add VSCode debugging configuration`
+
+---
+
 ## Vite Proxy Configuration (Frontend Integration)
 
 To proxy frontend API requests to the backend during development:

--- a/skills/frontend-shadcn/references/setup-guide.md
+++ b/skills/frontend-shadcn/references/setup-guide.md
@@ -446,6 +446,60 @@ import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/component
 
 ---
 
+## VSCode Debugging
+
+Configure VSCode to debug the Vite dev server and React application.
+
+### Launch Configuration
+
+**Create `.vscode/launch.json`:**
+
+```json
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Debug Dev Server",
+      "type": "node",
+      "request": "launch",
+      "cwd": "${workspaceFolder}",
+      "runtimeExecutable": "npx",
+      "runtimeArgs": ["vite"],
+      "skipFiles": ["<node_internals>/**", "**/node_modules/**"],
+      "console": "integratedTerminal"
+    },
+    {
+      "name": "Debug in Chrome",
+      "type": "chrome",
+      "request": "launch",
+      "url": "http://localhost:5173",
+      "webRoot": "${workspaceFolder}/src",
+      "sourceMaps": true
+    }
+  ]
+}
+```
+
+**Key patterns:**
+
+- "Debug Dev Server" runs Vite with Node.js debugging for server-side breakpoints
+- "Debug in Chrome" launches Chrome with DevTools protocol for client-side React debugging
+- `webRoot` maps to `src/` for accurate source map resolution
+- Default Vite port is `5173`
+
+### Using the Debugger
+
+**For client-side React debugging:**
+
+1. Start the dev server: `npm run dev`
+2. Select "Debug in Chrome" and press `F5`
+3. Set breakpoints in React components (`.tsx` files)
+4. Breakpoints pause execution in Chrome with VSCode controls
+
+**Commit:** `config: add VSCode debugging configuration`
+
+---
+
 ## Commit Message Format
 
 ```


### PR DESCRIPTION
Added VSCode launch.json debugging configurations to both backend-fastify and frontend-shadcn setup guides. Backend configuration enables TypeScript debugging with tsx and environment variable support. Frontend configuration provides both Vite dev server and Chrome DevTools debugging. Each section includes key patterns explanation and step-by-step usage instructions for developers.