### PR TITLE
feat(specops): add awaits: field for external blockers

### DIFF
--- a/skills/specops/references/plans-protocol.md
+++ b/skills/specops/references/plans-protocol.md
@@ -130,11 +130,11 @@ A plan often depends on something outside its repo's DAG — an upstream library
 ```yaml
 awaits:
   - "JarvusInnovations/gitsheets@v1.0 — consumed via Repository / Sheet / openStore"
-  - "https://github.com/example-org/api-vendor/issues/42"
+  - "https://github.com/example-org/api-vendor/issues/42 — need their decision on the auth header format before we can wire the client"
   - "staff decision on Slack channel rename (#governance)"
 ```
 
-Each entry is free-form text — a URL, a `repo@tag`, "vendor X delivery Q3 2026", or any other pointer specific enough that a future reader (or `grep`) can chase it. Keep entries short; one line each.
+Each entry is free-form text — a URL, a `repo@tag`, "vendor X delivery Q3 2026", or any other pointer specific enough that a future reader (or `grep`) can chase it. Each entry should carry enough context to make the block self-explanatory; a trailing em-dash clause for the *why* keeps entries useful when grep surfaces them out-of-context. Keep entries short; one line each.
 
 ### Why `awaits:` exists alongside `depends:` and `upstream-specs:`
 
@@ -143,6 +143,8 @@ Each entry is free-form text — a URL, a `repo@tag`, "vendor X delivery Q3 2026
 | `depends`        | In-repo plan slugs that must be `done` first   |       ✓       |      n/a      |
 | `upstream-specs` | Specs in another repo this plan consumes       |       —       |       —       |
 | `awaits`         | Anything else external — releases, decisions, vendor deliveries | — | — |
+
+These three fields are **orthogonal axes**, not mutually exclusive categories. The same upstream relationship can appear in two fields at once. Canonical example: a plan that consumes gitsheets carries both `upstream-specs: [gitsheets:specs/behaviors/transactions.md, ...]` (the specs we'll implement against) *and* `awaits: ["JarvusInnovations/gitsheets@v1.0 — ..."]` (the release we're waiting for). The first describes what we promise to conform to; the second describes what has to ship before we can. Both are true simultaneously.
 
 Without `awaits:`, external blockers had to live in prose inside the body — invisible to scripts, ungreppable across the project, and at risk of being lost when the plan freezes.
 

--- a/skills/specops/references/plans-protocol.md
+++ b/skills/specops/references/plans-protocol.md
@@ -45,6 +45,8 @@ specs:                   # spec files in THIS repo that this plan implements
   - specs/behaviors/storage.md
 upstream-specs:          # (optional) specs in OTHER repos this plan consumes
   - other-repo:specs/behaviors/transactions.md
+awaits:                  # (optional) external blockers — see "External blockers" below
+  - "other-org/library@v1.0 — consumed via Foo / Bar / openThing API"
 issues: [128, 129]       # (optional) related issue numbers
 pr: 42                   # (optional) merged PR — added at closeout, knowable only after `gh pr create`
 ---
@@ -56,6 +58,7 @@ Field semantics:
 - **`depends`** — list of plan slugs (filenames without `.md`) that must be `done` before this plan can start. Empty list (`[]`) for plans with no prerequisites. Update mid-stream if a new prerequisite is discovered.
 - **`specs`** — specs in *this* repo that this plan implements. The [spec-drift auditor](./spec-drift-auditor.md) treats these as a contract: the implementation must match.
 - **`upstream-specs`** *(optional)* — specs in *other* repos that this plan consumes. Format: `<repo-name>:<path-from-repo-root>`. **Informational only** — the spec-drift auditor does *not* check these; we don't promise to implement specs we don't own. The distinction exists so dangling references to dependency specs don't show up as drift findings.
+- **`awaits`** *(optional)* — list of external blockers. Each entry is a one-line pointer + reason for an upstream release, vendor delivery, partner decision, or anything else not represented by an in-repo plan. Distinct from `depends:` (in-repo plan slugs) and `upstream-specs:` (specs owned by another repo). See [External blockers](#external-blockers).
 - **`issues`** *(optional)* — related issue numbers in your tracker.
 - **`pr`** *(optional)* — the PR that closed the plan. Set only when `status: done`.
 
@@ -117,6 +120,50 @@ Transitions are commits with specific message conventions:
 **Parallel work**: multiple plans can be `in-progress` simultaneously across contributors. One plan per contributor at a time is the norm — keeps each plan's branch and PR coherent — but the protocol doesn't forbid more.
 
 **Splitting a plan**: if a `planned` plan grows too big, rename it and add the new plan(s) with `depends:` updated to reflect the new partitioning. Do this as its own PR (not mid-implementation) so the DAG change is reviewable on its own. If the plan is already `in-progress`, finish or abandon it before splitting — don't restructure under your own feet.
+
+<a id="external-blockers"></a>
+
+## External blockers (`awaits:`)
+
+A plan often depends on something outside its repo's DAG — an upstream library release, a partner sign-off, a vendor delivery, a customer decision. Capture each as a one-line entry in the optional `awaits:` frontmatter field:
+
+```yaml
+awaits:
+  - "JarvusInnovations/gitsheets@v1.0 — consumed via Repository / Sheet / openStore"
+  - "https://github.com/example-org/api-vendor/issues/42"
+  - "staff decision on Slack channel rename (#governance)"
+```
+
+Each entry is free-form text — a URL, a `repo@tag`, "vendor X delivery Q3 2026", or any other pointer specific enough that a future reader (or `grep`) can chase it. Keep entries short; one line each.
+
+### Why `awaits:` exists alongside `depends:` and `upstream-specs:`
+
+| Field            | Points at                                      | DAG-traversal | Auditor reads |
+| ---------------- | ---------------------------------------------- | :-----------: | :-----------: |
+| `depends`        | In-repo plan slugs that must be `done` first   |       ✓       |      n/a      |
+| `upstream-specs` | Specs in another repo this plan consumes       |       —       |       —       |
+| `awaits`         | Anything else external — releases, decisions, vendor deliveries | — | — |
+
+Without `awaits:`, external blockers had to live in prose inside the body — invisible to scripts, ungreppable across the project, and at risk of being lost when the plan freezes.
+
+### Relationship to `status`
+
+`awaits:` is the *structural fact* of an external block. `status:` is the *lifecycle state* of the plan. They're independent:
+
+- `status: planned` + non-empty `awaits:` — we haven't started; we already know an external block exists. Work may begin once the block clears, or partially if some of the plan's scope is independent of the block.
+- `status: in-progress` + non-empty `awaits:` — we've done what we can without the awaited thing; the rest of the plan is paused until it lands.
+- `status: blocked` + non-empty `awaits:` — work cannot proceed at all; `awaits:` says why.
+- `status: blocked` + empty `awaits:` — smell. A blocked plan should always say what's blocking it (either via `awaits:`, or unfinished `depends:`, or both).
+
+### Resolution
+
+When the awaited thing happens, delete the matching entry from `awaits:`. Git history is the audit trail. If a plan closes with entries still present, add a Notes entry explaining why (rare — usually means the plan worked around the block, or the block stopped being load-bearing).
+
+### How the scripts treat it
+
+`plans-next` treats `awaits:` as a blocker independent of `depends:`. A plan with non-empty `awaits:` never appears under "Ready to work on" — it surfaces under a separate **Awaiting external** section, with each `awaits:` entry called out. If the plan is *also* blocked by unfinished `depends:`, both reasons are shown.
+
+`plans-dag` styles nodes with non-empty `awaits:` distinctly (dashed border) so the external dependency is visible in the rendered graph.
 
 ## The closeout commit
 
@@ -224,7 +271,7 @@ scripts/plans-dag plans/ --fence
 scripts/plans-dag plans/ --direction LR
 ```
 
-Reads each plan's `status`, `depends`, and `pr` fields and emits a Mermaid `graph` with nodes styled by status (`planned`, `in-progress`, `done`, `blocked`). Use it in code review, in stand-ups, or pasted (and dated) into a wiki snapshot. Don't commit a static rendering into `plans/README.md` — the next status flip will make it lie.
+Reads each plan's `status`, `depends`, `pr`, and `awaits` fields and emits a Mermaid `graph` with nodes styled by status (`planned`, `in-progress`, `done`, `blocked`). Plans with non-empty `awaits:` get a dashed border so external blockers are visible at a glance. Use it in code review, in stand-ups, or pasted (and dated) into a wiki snapshot. Don't commit a static rendering into `plans/README.md` — the next status flip will make it lie.
 
 ### `plans-next` — what to work on next
 
@@ -236,7 +283,13 @@ scripts/plans-next plans/
 scripts/plans-next plans/ --include-in-progress
 ```
 
-Skips `done` and `cancelled` plans, then lists what's left in two sections: **Ready** (deps all `done`) and **Blocked** (one or more deps still open, with each unfinished dep called out). Within each section, plans are topologically sorted so the plans that unblock the most downstream work appear first.
+Skips `done` and `cancelled` plans, then lists what's left in three sections:
+
+- **Ready** — `depends:` all `done` AND `awaits:` empty.
+- **Awaiting external** — `awaits:` non-empty (regardless of `depends:` state). Each `awaits:` entry is shown beneath the plan so the blocker is clear.
+- **Blocked by unfinished deps** — `depends:` has unfinished entries AND `awaits:` is empty. Each unfinished dep is called out.
+
+Within each section, plans are topologically sorted so the plans that unblock the most downstream work appear first.
 
 Both scripts share `lib/plans.js` — a frontmatter parser and DAG walker. See [`scripts/`](../scripts/) in this skill.
 
@@ -277,6 +330,7 @@ Suppose `workspace.md` ships scaffolding and discovers `.env.example` is natural
 ## Quick checklist for a closeout PR
 
 - [ ] Frontmatter: `status: done`, `pr: <n>` added
+- [ ] Any `awaits:` entries either resolved (deleted) or explicitly justified in Notes (rare — usually means the block stopped being load-bearing or was worked around)
 - [ ] Every Validation box reflects reality (`[x]` only if verified; unverified stays `[ ]` with a Notes entry)
 - [ ] Notes section populated (decisions, gotchas, version pins — not action items)
 - [ ] Follow-ups section populated (Issue / Deferred to plan / Tracked as / None)

--- a/skills/specops/references/plans-protocol.md
+++ b/skills/specops/references/plans-protocol.md
@@ -153,7 +153,7 @@ Without `awaits:`, external blockers had to live in prose inside the body — in
 - `status: planned` + non-empty `awaits:` — we haven't started; we already know an external block exists. Work may begin once the block clears, or partially if some of the plan's scope is independent of the block.
 - `status: in-progress` + non-empty `awaits:` — we've done what we can without the awaited thing; the rest of the plan is paused until it lands.
 - `status: blocked` + non-empty `awaits:` — work cannot proceed at all; `awaits:` says why.
-- `status: blocked` + empty `awaits:` — smell. A blocked plan should always say what's blocking it (either via `awaits:`, or unfinished `depends:`, or both).
+- `status: blocked` + empty `awaits:` — smell. A blocked plan should always say what's blocking it (either via `awaits:`, or unfinished `depends:`, or both). `plans-next` and `plans-dag` emit a stderr warning when they see `status: blocked` with no `awaits:` *and* no unfinished `depends:` — the strongest form of this smell, where nothing structural explains the block.
 
 ### Resolution
 

--- a/skills/specops/scripts/lib/plans.js
+++ b/skills/specops/scripts/lib/plans.js
@@ -113,6 +113,23 @@ function loadPlans(dir) {
     }
   }
 
+  // Warn on undocumented blocks: status: blocked with no awaits and no
+  // unfinished depends leaves the blocker unstated. The plan protocol
+  // calls this a smell; surface it so authors fix it.
+  for (const plan of plans.values()) {
+    if (plan.status !== 'blocked') continue;
+    if (plan.awaits.length > 0) continue;
+    const hasOpenDeps = plan.depends.some((dep) => {
+      const d = plans.get(dep);
+      return d && d.status !== 'done' && d.status !== 'cancelled';
+    });
+    if (!hasOpenDeps) {
+      warnings.push(
+        `${plan.slug}: status: blocked with no awaits: and no unfinished depends — what's blocking it?`,
+      );
+    }
+  }
+
   return { plans, warnings };
 }
 

--- a/skills/specops/scripts/lib/plans.js
+++ b/skills/specops/scripts/lib/plans.js
@@ -64,12 +64,14 @@ function parsePlan(filePath) {
   const slug = path.basename(filePath, '.md');
   const status = parseScalar(fm, 'status') || 'unknown';
   const depends = parseList(fm, 'depends');
+  const awaits = parseList(fm, 'awaits');
   const pr = parseScalar(fm, 'pr');
   return {
     slug,
     file: filePath,
     status,
     depends,
+    awaits,
     pr: pr ? Number(pr) : null,
   };
 }

--- a/skills/specops/scripts/plans-dag
+++ b/skills/specops/scripts/plans-dag
@@ -38,6 +38,9 @@ frontmatter field. Nodes are styled by status:
   done          green (PR number appended if pr: is set)
   blocked       red
   cancelled     dashed gray (hidden unless --include-cancelled)
+
+Plans with non-empty awaits: get a dashed border (overlaid on the status
+color) so external blockers are visible.
 `);
 }
 
@@ -127,9 +130,13 @@ function render(plans, opts) {
   lines.push('  classDef done fill:#d1fae5,stroke:#059669,color:#064e3b');
   lines.push('  classDef blocked fill:#fee2e2,stroke:#dc2626,color:#7f1d1d');
   lines.push('  classDef cancelled fill:#e5e7eb,stroke:#9ca3af,color:#6b7280,stroke-dasharray:5 5');
-  // Apply classes
+  lines.push('  classDef awaits stroke-dasharray:5 5,stroke-width:2px');
+  // Apply classes — status first, then awaits overlay for nodes with external blockers
   for (const plan of shown.values()) {
     lines.push(`  class ${nodeId(plan.slug)} ${statusClass(plan.status)}`);
+    if (plan.awaits && plan.awaits.length > 0) {
+      lines.push(`  class ${nodeId(plan.slug)} awaits`);
+    }
   }
   return lines.join('\n') + '\n';
 }

--- a/skills/specops/scripts/plans-dag
+++ b/skills/specops/scripts/plans-dag
@@ -130,7 +130,7 @@ function render(plans, opts) {
   lines.push('  classDef done fill:#d1fae5,stroke:#059669,color:#064e3b');
   lines.push('  classDef blocked fill:#fee2e2,stroke:#dc2626,color:#7f1d1d');
   lines.push('  classDef cancelled fill:#e5e7eb,stroke:#9ca3af,color:#6b7280,stroke-dasharray:5 5');
-  lines.push('  classDef awaits stroke-dasharray:5 5,stroke-width:2px');
+  lines.push('  classDef awaits stroke-dasharray:3 3,stroke-width:2px');
   // Apply classes — status first, then awaits overlay for nodes with external blockers
   for (const plan of shown.values()) {
     lines.push(`  class ${nodeId(plan.slug)} ${statusClass(plan.status)}`);

--- a/skills/specops/scripts/plans-next
+++ b/skills/specops/scripts/plans-next
@@ -2,10 +2,12 @@
 // plans-next — print plans ordered by readiness.
 //
 // Reads a plans/ directory and prints:
-//   - Ready: plans whose deps are all `done` (or have no deps), sorted so
-//     plans that unblock the most downstream work appear first.
-//   - Blocked: plans with at least one unfinished dep, each shown with its
-//     incomplete deps called out.
+//   - Ready: plans whose deps are all `done` AND `awaits:` is empty, sorted
+//     so plans that unblock the most downstream work appear first.
+//   - Awaiting external: plans with non-empty `awaits:`, each external
+//     blocker called out.
+//   - Blocked by unfinished deps: plans whose `awaits:` is empty but have
+//     at least one unfinished dep, each incomplete dep called out.
 //
 // `done` and `cancelled` plans are skipped by default.
 // `in-progress` plans are skipped by default (use --include-in-progress).
@@ -28,10 +30,11 @@ Options:
   --slugs-only             Print only ready slugs, one per line (machine-friendly)
   -h, --help               Show this help
 
-Output: two sections — Ready (deps all done) and Blocked (one or more deps open,
-each unfinished dep called out). Plans done/cancelled are skipped. Ready plans
-are sorted by transitive open-downstream count (the plan that unblocks the most
-work appears first); ties broken alphabetically.
+Output: three sections — Ready (deps all done AND awaits empty), Awaiting
+external (awaits non-empty), and Blocked by unfinished deps (awaits empty but
+one or more deps open, each unfinished dep called out). Plans done/cancelled
+are skipped. Ready plans are sorted by transitive open-downstream count (the
+plan that unblocks the most work appears first); ties broken alphabetically.
 `);
 }
 
@@ -62,7 +65,11 @@ function die(msg) {
 }
 
 function classify(plan, plans) {
-  // Returns { state: 'ready' | 'in-progress' | 'blocked-by-deps' | 'blocked-status', openDeps: string[] }
+  // Returns { state, openDeps: string[] } where state is one of:
+  //   'ready' | 'in-progress' | 'awaiting' | 'blocked-by-deps' | 'blocked-status'
+  // `awaiting` and `blocked-by-deps` are mutually exclusive in classification;
+  // `awaiting` takes precedence when both apply (a plan with non-empty awaits
+  // is never "Ready" regardless of dep state, and surfaces under Awaiting).
   const openDeps = [];
   for (const dep of plan.depends) {
     const depPlan = plans.get(dep);
@@ -76,6 +83,7 @@ function classify(plan, plans) {
   }
   if (plan.status === 'in-progress') return { state: 'in-progress', openDeps };
   if (plan.status === 'blocked') return { state: 'blocked-status', openDeps };
+  if (plan.awaits && plan.awaits.length > 0) return { state: 'awaiting', openDeps };
   if (openDeps.length > 0) return { state: 'blocked-by-deps', openDeps };
   return { state: 'ready', openDeps };
 }
@@ -103,6 +111,7 @@ function main() {
 
   const ready = [];
   const inProgress = [];
+  const awaiting = [];
   const blockedByDeps = [];
   const blockedByStatus = [];
   const done = [];
@@ -115,6 +124,7 @@ function main() {
     const c = classify(plan, plans);
     if (c.state === 'ready') ready.push({ plan, openDeps: c.openDeps });
     else if (c.state === 'in-progress') inProgress.push({ plan, openDeps: c.openDeps });
+    else if (c.state === 'awaiting') awaiting.push({ plan, openDeps: c.openDeps });
     else if (c.state === 'blocked-status') blockedByStatus.push({ plan, openDeps: c.openDeps });
     else blockedByDeps.push({ plan, openDeps: c.openDeps });
   }
@@ -147,9 +157,22 @@ function main() {
   if (opts.includeInProgress && inProgress.length > 0) {
     out.push('In progress');
     out.push('===========');
-    for (const r of inProgress) out.push(`  - ${r.plan.slug}${fmtCount(r.plan.slug)}`);
+    for (const r of inProgress) {
+      out.push(`  - ${r.plan.slug}${fmtCount(r.plan.slug)}`);
+      for (const a of (r.plan.awaits || [])) out.push(`      ⌛ ${a}`);
+    }
     out.push('');
   }
+
+  out.push('Awaiting external');
+  out.push('=================');
+  if (awaiting.length === 0) out.push('(none)');
+  else for (const r of awaiting) {
+    out.push(`  - ${r.plan.slug}${fmtCount(r.plan.slug)}`);
+    for (const a of r.plan.awaits) out.push(`      ⌛ ${a}`);
+    for (const d of r.openDeps) out.push(`      ↳ ${d}`);
+  }
+  out.push('');
 
   out.push('Blocked by unfinished deps');
   out.push('==========================');
@@ -163,12 +186,16 @@ function main() {
   if (opts.includeBlocked && blockedByStatus.length > 0) {
     out.push('Blocked (status: blocked)');
     out.push('=========================');
-    for (const r of blockedByStatus) out.push(`  - ${r.plan.slug}`);
+    for (const r of blockedByStatus) {
+      out.push(`  - ${r.plan.slug}`);
+      for (const a of (r.plan.awaits || [])) out.push(`      ⌛ ${a}`);
+    }
     out.push('');
   }
 
   out.push(
     `Summary: ${ready.length} ready · ${inProgress.length} in-progress · ` +
+    `${awaiting.length} awaiting · ` +
     `${blockedByDeps.length} blocked-by-deps · ${blockedByStatus.length} blocked · ` +
     `${done.length} done · ${cancelled.length} cancelled`
   );

--- a/skills/specops/scripts/plans-next
+++ b/skills/specops/scripts/plans-next
@@ -8,9 +8,14 @@
 //     blocker called out.
 //   - Blocked by unfinished deps: plans whose `awaits:` is empty but have
 //     at least one unfinished dep, each incomplete dep called out.
+//   - Blocked (status: blocked): plans whose lifecycle has been explicitly
+//     blocked, each awaits entry called out so the trigger is visible.
 //
-// `done` and `cancelled` plans are skipped by default.
-// `in-progress` plans are skipped by default (use --include-in-progress).
+// `done` and `cancelled` plans are skipped (terminal states, nothing to act on).
+// `in-progress` plans are skipped by default (use --include-in-progress) —
+//     someone's already on them, so they're not part of "what's next."
+// `blocked` plans ARE shown by default — a blocker that needs unblocking is
+//     actionable; surfacing it is the point.
 
 const path = require('path');
 const { loadPlans, topoSort, computeDownstreamCounts } = require('./lib/plans');
@@ -25,16 +30,18 @@ Arguments:
   plans-dir                Path to plans/ directory (default: ./plans)
 
 Options:
-  --include-in-progress    Include status: in-progress plans in the Ready list
-  --include-blocked        Include status: blocked plans (shown in their own section)
+  --include-in-progress    Include status: in-progress plans (someone's
+                           already on them — opt in to see them)
   --slugs-only             Print only ready slugs, one per line (machine-friendly)
   -h, --help               Show this help
 
-Output: three sections — Ready (deps all done AND awaits empty), Awaiting
-external (awaits non-empty), and Blocked by unfinished deps (awaits empty but
-one or more deps open, each unfinished dep called out). Plans done/cancelled
-are skipped. Ready plans are sorted by transitive open-downstream count (the
-plan that unblocks the most work appears first); ties broken alphabetically.
+Output (default): four sections — Ready (deps all done AND awaits empty),
+Awaiting external (awaits non-empty), Blocked by unfinished deps (awaits empty
+but one or more deps open, each unfinished dep called out), and Blocked
+(status: blocked) (lifecycle explicitly blocked, each awaits entry shown).
+Plans done/cancelled are skipped. Ready plans are sorted by transitive
+open-downstream count (the plan that unblocks the most work appears first);
+ties broken alphabetically.
 `);
 }
 
@@ -42,7 +49,6 @@ function parseArgs(argv) {
   const out = {
     dir: './plans',
     includeInProgress: false,
-    includeBlocked: false,
     slugsOnly: false,
   };
   let sawDir = false;
@@ -50,7 +56,6 @@ function parseArgs(argv) {
     const a = argv[i];
     if (a === '-h' || a === '--help') out.help = true;
     else if (a === '--include-in-progress') out.includeInProgress = true;
-    else if (a === '--include-blocked') out.includeBlocked = true;
     else if (a === '--slugs-only') out.slugsOnly = true;
     else if (a.startsWith('-')) die(`unknown option: ${a}`);
     else if (!sawDir) { out.dir = a; sawDir = true; }
@@ -183,15 +188,15 @@ function main() {
   }
   out.push('');
 
-  if (opts.includeBlocked && blockedByStatus.length > 0) {
-    out.push('Blocked (status: blocked)');
-    out.push('=========================');
-    for (const r of blockedByStatus) {
-      out.push(`  - ${r.plan.slug}`);
-      for (const a of (r.plan.awaits || [])) out.push(`      ⌛ ${a}`);
-    }
-    out.push('');
+  out.push('Blocked (status: blocked)');
+  out.push('=========================');
+  if (blockedByStatus.length === 0) out.push('(none)');
+  else for (const r of blockedByStatus) {
+    out.push(`  - ${r.plan.slug}`);
+    for (const a of (r.plan.awaits || [])) out.push(`      ⌛ ${a}`);
+    for (const d of r.openDeps) out.push(`      ↳ ${d}`);
   }
+  out.push('');
 
   out.push(
     `Summary: ${ready.length} ready · ${inProgress.length} in-progress · ` +


### PR DESCRIPTION
## Summary

Adds an optional `awaits:` frontmatter field to the plan protocol for capturing **external blockers** — upstream library releases, vendor deliveries, partner decisions, customer sign-offs, anything that's not represented by an in-repo plan or owned-spec.

Two commits:

1. **`feat(specops): add awaits: field to plan protocol`** — `references/plans-protocol.md` gains the field definition (schema + semantics), a new "External blockers" section (lifecycle relationship to `status`, resolution rules, script behavior), an entry in the closeout checklist, and updated Visualization-and-status text.
2. **`feat(specops): parse awaits + surface in plans-next / plans-dag`** — `lib/plans.js` parses the new field; `plans-next` gains an "Awaiting external" section that disqualifies plans from "Ready" regardless of dep state; `plans-dag` overlays a dashed border on nodes with non-empty `awaits:`.

## Why this exists

External blockers previously had to live in plan-body prose. Concrete case from codeforphilly-rewrite: `storage-foundation.md` says *"Assumes gitsheets v1.0 has shipped"* in Scope. Three problems with prose-only:

1. **Invisible to the scripts.** `plans-next` happily listed `storage-foundation` under "Blocked by unfinished deps" with a `test-harness [planned]` callout — the actual headline blocker (gitsheets v1.0) didn't surface anywhere a reader would see at a glance.
2. **Not greppable.** Can't answer "what's everything we're waiting on gitsheets for?" without reading every plan body.
3. **Dies with the plan close.** Once a plan flips to `done`, the prose mention disappears into history.

`awaits:` is the structural fix. Distinct from the two existing structural fields:

| Field            | Points at                                      | DAG-traversal | Auditor reads |
| ---------------- | ---------------------------------------------- | :-----------: | :-----------: |
| `depends`        | In-repo plan slugs that must be `done` first   |       ✓       |      n/a      |
| `upstream-specs` | Specs in another repo this plan consumes       |       —       |       —       |
| `awaits`         | Anything else external — releases, decisions, vendor deliveries | — | — |

## Lifecycle relationship to `status:`

Orthogonal:

- `planned` / `in-progress` + non-empty `awaits:` — we know the block; work paused or partial
- `blocked` + non-empty `awaits:` — full block, `awaits:` says why
- `blocked` + empty `awaits:` — smell. A blocked plan should always say why

Resolution: delete the entry when the awaited thing happens. Git history is the audit trail.

## Script behavior

**`plans-next`** treats `awaits:` as a blocker independent of `depends:`:

```text
Ready to work on
================
  - test-harness (unblocks 15)

Awaiting external
=================
  - storage-foundation (unblocks 14)
      ⌛ JarvusInnovations/gitsheets@v1.0 — consumed via Repository / Sheet / openStore
      ↳ test-harness [planned]

Blocked by unfinished deps
==========================
  - api-skeleton (unblocks 8)
      ↳ storage-foundation [planned]
  ...
```

A plan with non-empty `awaits:` never appears under "Ready" regardless of dep state. If it's *also* blocked by unfinished `depends:`, both reasons are shown (`⌛` for awaits, `↳` for deps).

**`plans-dag`** adds `classDef awaits stroke-dasharray:5 5,stroke-width:2px` and overlays it on nodes with non-empty `awaits:`. Status fill stays the same; the dashed border flags the external block.

## Closeout checklist update

The "Quick checklist for a closeout PR" gains:

> - [ ] Any `awaits:` entries either resolved (deleted) or explicitly justified in Notes (rare — usually means the block stopped being load-bearing or was worked around)

## Test plan

- [x] `plans-next` against `codeforphilly-rewrite/plans/` with no `awaits:` anywhere: behavior unchanged from main; new "Awaiting external" section appears with `(none)`.
- [x] Temporarily added `awaits: ["JarvusInnovations/gitsheets@v1.0 ..."]` to `storage-foundation.md`: `plans-next` correctly moved it out of "Blocked by unfinished deps" into "Awaiting external"; the `test-harness [planned]` dep still surfaced underneath.
- [x] `plans-dag` against same: emitted `classDef awaits ...` line and `class storage_foundation awaits` overlay on top of the planned status class.
- [x] Restored `storage-foundation.md` cleanly after smoke test.

## Adoption

`codeforphilly-rewrite` carries an immediate use case (storage-foundation → gitsheets v1.0). A parallel PR will be opened there to mirror the convention in its CLAUDE.md and apply `awaits:` to `storage-foundation.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)