### PR TITLE
feat(skills): add agent-dev-workflow skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,5 +15,6 @@ npx skills add JarvusInnovations/agent-skills
 - `frontend-shadcn`: Frontend development using Vite+React+ShadCN+Tailwind
 - `backend-fastify`: Backend development using Node.js+Fastify
 - `mobile-flutter`: Mobile app development using Flutter+Riverpod+go_router
+- `agent-dev-workflow`: Agent-friendly local dev — `bin/` task-runner, worktree-isolated Postgres databases + ports, dedicated test DB
 
 `specops` (spec-driven development) now lives in its own repo: [JarvusInnovations/specops](https://github.com/JarvusInnovations/specops) — install with `npx skills add JarvusInnovations/specops`.

--- a/skills/agent-dev-workflow/SKILL.md
+++ b/skills/agent-dev-workflow/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: agent-dev-workflow
+description: Set up an agent-friendly local dev workflow — a bin/ task-runner (inspired by GitHub's scripts-to-rule-them-all) over a shared Postgres container that gives every git worktree its own isolated database and port, plus a dedicated test database so tests never clobber dev data. Use this whenever a project needs worktree-isolated local development, when setting up for AI agent orchestrators (Conductor and similar) that spin up a worktree per session and register setup/run/cleanup commands, when multiple copies of a backend must run concurrently on one machine, when replacing a docker-compose-for-local-postgres setup, or when tests keep wiping local dev/demo data. Triggers on "bin/ scripts", "worktree isolation", "per-worktree database/port", "scripts to rule them all", "agent dev environment", "setup/run/cleanup scripts", or tests clobbering the dev database.
+---
+
+# Agent-friendly dev workflow (bin/ + worktree isolation)
+
+This skill scaffolds a `bin/` task-runner that lets **many copies of a project run
+concurrently on one machine** — one per git worktree — each with its own database
+and port, sharing a single Postgres container. It's the contract AI agent
+orchestrators (Conductor and similar) want: register `setup` / `run` / `cleanup`
+once and every session gets an isolated environment for free. As a high-value side
+effect, tests run against a dedicated database and **can never wipe your dev data**.
+
+It's modeled on GitHub's *scripts-to-rule-them-all*, but uses `bin/` (the name
+`script/` never caught on) and adds the worktree-isolation layer.
+
+## When this is the right tool
+
+A project backed by Postgres where you want any of: concurrent worktree dev,
+orchestrator setup/run/cleanup hooks, an end to tests clobbering dev data, or a
+replacement for a docker-compose-just-for-local-postgres. If there's no database,
+most of this doesn't apply. If there's no concurrency need *and* tests already use
+a separate DB, the payoff is small.
+
+## The core idea: identity derives from the worktree
+
+One shared Postgres container (started once, reused by name — path-independent, so
+it survives worktree deletion). Each context gets a **database** and a **port**
+derived from its worktree path:
+
+| Context | Database | Backend port |
+|---|---|---|
+| Main checkout | the canonical name (durable dev data) | the default (e.g. 4000) |
+| Each agent worktree | `app_<hash-of-path>` (isolated) | next free port |
+| The test runner | `app_test` (forced) | n/a |
+
+Because identity comes from the path, two sessions never collide and re-running
+setup is idempotent. Every derived value has an env override (`APP_DATABASE`,
+`APP_PG_PORT`, `PORT`, …) for explicit orchestrator control.
+
+## What's invariant vs. project-specific
+
+The whole point of distilling this from several real Postgres-backed projects is to
+know which parts you copy verbatim and which you adapt.
+
+**Invariant** (copy from `references/bin/`, just swap the `app`/`APP_` prefix):
+
+- worktree-aware DB naming (`app_db_name`, `is_main_worktree`, `app_hash`)
+- shared-container management (`ensure_postgres`, `wait_for_postgres`, `app_psql`)
+- DB create/recreate helpers; the `setup`/`reset-db`/`db`/`cleanup`/`test` scripts
+- port picking (`port_in_use`, `find_available_port`, `app_pick_port`) — **including
+  the macOS `lsof`/`ss` split; do not "simplify" it away** (see gotchas)
+- stdout=env / stderr=status discipline
+
+**Project-specific** (the knobs you set):
+
+- the prefix, PG user/password/image, container/volume names, default PG port
+- `app_server_dir` — repo root (single package) vs a subdir (monorepo)
+- `app_migrate` — how migrations run → **`references/migrations-and-seeds.md`**
+- single-service `dev` (frontend runs separately) vs fullstack `dev` (starts both,
+  kills both) → use `references/bin/dev` or `references/bin/dev-fullstack`
+- whether the project seeds, and whether it has prod snapshots at all
+
+## Build order
+
+1. **Read the relevant references first** (below) — they encode hard-won bugs.
+2. Copy `references/bin/*` into the project's `bin/`, rename the prefix, fill the
+   constants in `_common.sh`. Pick a PG host port well outside 5432.
+3. Set `app_server_dir` and `app_migrate` for this project
+   (`references/migrations-and-seeds.md`).
+4. Choose the `dev` variant (single-service vs `dev-fullstack`).
+5. Wire **test isolation** — the preload that points tests at `app_test`
+   (`references/test-isolation.md`). This is the highest-value step; do it even if
+   you skip everything else.
+6. `chmod +x bin/*` (not `_common.sh`). Remove any `docker-compose.yml` that only
+   templated local Postgres, and update `.env.example` + the project's agent docs
+   (CLAUDE.md or equivalent) to point at `bin/`.
+7. **Verify** end to end (don't assume): `bin/setup` on a clean checkout; the
+   sentinel-row test from `test-isolation.md`; `bin/dev` twice concurrently lands on
+   two different ports; `bin/cleanup` in a throwaway worktree leaves the main DB
+   intact. `bash -n` every script.
+
+## Reference files
+
+| File | Read when |
+|---|---|
+| `references/bin/` | always — the script templates you copy + adapt |
+| `references/test-isolation.md` | wiring tests to `app_test` (the preload) — almost always |
+| `references/migrations-and-seeds.md` | setting `app_migrate`; deciding on seeds |
+| `references/gotchas.md` | **before writing port logic or picking a PG image** — the silent-failure bugs |
+| `references/orchestrator-integration.md` | wiring Conductor/orchestrator setup/run/cleanup; the stdout/stderr contract |
+| `references/snapshots.md` | only if the project has a production DB to snapshot (skip for greenfield) |
+
+## Guardrails
+
+- Keep the scripts to **database + process lifecycle**. Rich demo/fixture data is
+  the app's concern and churns fast — at most a thin idempotent seed hook
+  (`migrations-and-seeds.md`). A bloated `bin/` stops being portable.
+- These are dev-only. **CI keeps its own explicit `DATABASE_URL`** against an
+  ephemeral DB; the test preload's `??=` defers to it. Verify CI stays green; you
+  shouldn't need to touch the CI workflow.
+- Don't drop the canonical dev DB casually — `bin/cleanup` guards it behind
+  `--force`; `bin/reset-db` is the intended "start the main DB over" path.

--- a/skills/agent-dev-workflow/references/bin/_common.sh
+++ b/skills/agent-dev-workflow/references/bin/_common.sh
@@ -1,0 +1,173 @@
+# Shared functions for <PROJECT> development scripts. Source this; don't run it.
+#
+# This is the invariant core of the agent-dev-workflow pattern. A single shared
+# Postgres container hosts a SEPARATE DATABASE per context (main checkout, each
+# agent worktree, the test runner), and each context binds a free port — so many
+# worktrees run at once without clobbering each other.
+#
+# TO ADAPT: replace the `app`/`APP_` prefix with a short one for your project
+# (e.g. a 2-3 letter initialism) and set the constants below. Pick a PG host port
+# well outside the common 5432 to avoid colliding with other local Postgres instances.
+
+set -euo pipefail
+
+APP_PG_USER="app"
+APP_PG_PASSWORD="app"
+APP_PG_IMAGE="postgres:17-alpine"     # see gotchas.md before choosing 18
+APP_CONTAINER_NAME="app-postgres"
+APP_VOLUME_NAME="app-pgdata"
+
+app_root() {
+  git rev-parse --show-toplevel
+}
+
+# Where the backend lives. Single-package repo → app_root; monorepo → a subdir
+# (e.g. "$(app_root)/server" or "$(app_root)/apps/server"). Adjust per project.
+app_server_dir() {
+  echo "$(app_root)"
+}
+
+app_pg_port() {
+  echo "${APP_PG_PORT:-5432}"   # pick a project-specific default (e.g. 5532)
+}
+
+# ── Database naming: one DB per context ──────────────────────────────────────
+# APP_DATABASE set → that name (the test runner / orchestrator forces this).
+# main worktree    → the canonical name (your durable dev data).
+# other worktree   → app_<hash-of-path> (isolated, stable per worktree).
+is_main_worktree() {
+  local worktree_root main_worktree
+  worktree_root="$(app_root)"
+  main_worktree="$(git worktree list --porcelain | head -1 | sed 's/^worktree //')"
+  [ "$worktree_root" = "$main_worktree" ]
+}
+
+# Portable 8-char hex hash (md5sum on Linux/coreutils, md5 on BSD/macOS).
+app_hash() {
+  if command -v md5sum &>/dev/null; then
+    echo -n "$1" | md5sum | head -c 8
+  else
+    echo -n "$1" | md5 -q | head -c 8
+  fi
+}
+
+app_db_name() {
+  if [ -n "${APP_DATABASE:-}" ]; then
+    echo "$APP_DATABASE"
+    return
+  fi
+  if is_main_worktree; then
+    echo "app"
+  else
+    echo "app_$(app_hash "$(app_root)")"
+  fi
+}
+
+app_database_url() {
+  echo "postgres://${APP_PG_USER}:${APP_PG_PASSWORD}@localhost:$(app_pg_port)/$(app_db_name)"
+}
+
+# ── Shared Postgres container ────────────────────────────────────────────────
+ensure_postgres() {
+  local container="$APP_CONTAINER_NAME" port
+  port="$(app_pg_port)"
+  if docker inspect "$container" &>/dev/null; then
+    if [ "$(docker inspect -f '{{.State.Running}}' "$container")" != "true" ]; then
+      echo "Starting existing postgres container..." >&2
+      docker start "$container" >/dev/null
+    fi
+  else
+    echo "Creating postgres container on port ${port}..." >&2
+    docker run -d \
+      --name "$container" \
+      -p "${APP_PG_BIND:-127.0.0.1}:${port}:5432" \
+      -e POSTGRES_USER="$APP_PG_USER" \
+      -e POSTGRES_PASSWORD="$APP_PG_PASSWORD" \
+      -e POSTGRES_DB=app \
+      -v "${APP_VOLUME_NAME}:/var/lib/postgresql/data" \
+      "$APP_PG_IMAGE" >/dev/null
+  fi
+  wait_for_postgres
+}
+
+wait_for_postgres() {
+  local container="$APP_CONTAINER_NAME" attempts=0
+  while ! docker exec "$container" pg_isready -U "$APP_PG_USER" -q 2>/dev/null; do
+    attempts=$((attempts + 1))
+    if [ "$attempts" -ge 30 ]; then
+      echo "ERROR: postgres did not become ready after 30 seconds" >&2
+      return 1
+    fi
+    sleep 1
+  done
+}
+
+# psql inside the container — no host psql needed. Default DB = maintenance 'postgres'.
+app_psql() {
+  docker exec -i "$APP_CONTAINER_NAME" psql -U "$APP_PG_USER" "$@"
+}
+
+app_ensure_db() {
+  local db="$1" exists
+  exists="$(app_psql -d postgres -tAc "SELECT 1 FROM pg_database WHERE datname = '${db}'" 2>/dev/null || true)"
+  if [ "$exists" != "1" ]; then
+    echo "Creating database ${db}..." >&2
+    app_psql -d postgres -c "CREATE DATABASE ${db} OWNER ${APP_PG_USER}" >/dev/null
+  fi
+}
+
+app_recreate_db() {
+  local db="$1"
+  app_psql -d postgres -c "
+    SELECT pg_terminate_backend(pid) FROM pg_stat_activity
+    WHERE datname = '${db}' AND pid <> pg_backend_pid()
+  " >/dev/null 2>&1 || true
+  echo "Dropping database ${db}..." >&2
+  app_psql -d postgres -c "DROP DATABASE IF EXISTS ${db}" >/dev/null
+  echo "Creating database ${db}..." >&2
+  app_psql -d postgres -c "CREATE DATABASE ${db} OWNER ${APP_PG_USER}" >/dev/null
+}
+
+# Run migrations against a DATABASE_URL. PROJECT-SPECIFIC — see migrations-and-seeds.md.
+app_migrate() {
+  local url="$1"
+  echo "Running migrations..." >&2
+  (cd "$(app_server_dir)" && DATABASE_URL="$url" bun run db:migrate) >&2
+}
+
+# ── Per-context port picking ─────────────────────────────────────────────────
+# CRITICAL (see gotchas.md): use lsof on macOS, ss on Linux. `ss` does NOT exist
+# on macOS and fails *silently* — without this split every port reads "free" and
+# concurrent worktrees all collide on the same port. If neither tool exists,
+# assume "in use" so we skip rather than double-bind.
+port_in_use() {
+  if command -v lsof &>/dev/null; then
+    lsof -iTCP:"$1" -sTCP:LISTEN -P -n &>/dev/null
+  elif command -v ss &>/dev/null; then
+    ss -tlnp 2>/dev/null | grep -q ":$1 "
+  else
+    return 0
+  fi
+}
+
+# First free port in [start, end].
+find_available_port() {
+  local start="$1" end="$2" port
+  for port in $(seq "$start" "$end"); do
+    if ! port_in_use "$port"; then
+      echo "$port"
+      return
+    fi
+  done
+  echo "ERROR: no available port in range ${start}-${end}" >&2
+  return 1
+}
+
+# The backend port for this context. Always scans FROM the default so the main
+# port is reused when free (not skipped on worktree identity); collisions are
+# detected by real listen-state. Override with PORT.
+app_pick_port() {
+  if [ -n "${PORT:-}" ]; then echo "$PORT"; return; fi
+  if ! port_in_use 4000; then echo "4000"; return; fi
+  find_available_port 4001 4099
+}

--- a/skills/agent-dev-workflow/references/bin/cleanup
+++ b/skills/agent-dev-workflow/references/bin/cleanup
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Drop this worktree's database (leaves the shared container running for others).
+# Refuses to drop the canonical main-worktree DB unless forced.
+#
+# Usage:
+#   bin/cleanup            # drop this worktree's derived DB
+#   bin/cleanup --force    # allow dropping the canonical dev DB
+#
+# Env overrides: APP_DATABASE, APP_PG_PORT.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/_common.sh"
+
+root="$(app_root)"
+
+# If a fullstack bin/dev wrote a PID file, stop that session's process group first.
+# (Single-service setups can omit this block.)
+pidfile="$root/.dev.pid"
+if [ -f "$pidfile" ]; then
+  dev_pid="$(cat "$pidfile")"
+  if kill -0 "$dev_pid" 2>/dev/null; then
+    echo "Stopping dev session (PID $dev_pid)..." >&2
+    kill "$dev_pid" 2>/dev/null || true
+  fi
+  rm -f "$pidfile"
+fi
+
+db="$(app_db_name)"
+if [ "$db" = "app" ] && [ "${1:-}" != "--force" ]; then
+  echo "Refusing to drop the canonical dev database. Use bin/reset-db, or --force." >&2
+  exit 1
+fi
+
+app_psql -d postgres -c "
+  SELECT pg_terminate_backend(pid) FROM pg_stat_activity
+  WHERE datname = '${db}' AND pid <> pg_backend_pid()
+" >/dev/null 2>&1 || true
+app_psql -d postgres -c "DROP DATABASE IF EXISTS ${db}" >/dev/null
+echo "Dropped database ${db}" >&2

--- a/skills/agent-dev-workflow/references/bin/db
+++ b/skills/agent-dev-workflow/references/bin/db
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Run SQL against this context's database, or open an interactive psql shell.
+#
+# Usage:
+#   bin/db "SELECT count(*) FROM users"
+#   echo "SELECT 1" | bin/db
+#   bin/db                       # interactive shell
+#
+# Env overrides: APP_DATABASE, APP_PG_PORT.
+# (Some projects name this script `bin/query` — same thing.)
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/_common.sh"
+
+db="$(app_db_name)"
+
+if [ $# -gt 0 ]; then
+  app_psql -d "$db" -c "$1"
+elif [ ! -t 0 ]; then
+  app_psql -d "$db"        # piped stdin
+else
+  docker exec -it "$APP_CONTAINER_NAME" psql -U "$APP_PG_USER" -d "$db"
+fi

--- a/skills/agent-dev-workflow/references/bin/dev
+++ b/skills/agent-dev-workflow/references/bin/dev
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Start the backend dev server with an auto-derived DATABASE_URL on a free port.
+#
+# This is the SINGLE-SERVICE variant (backend only) — correct when the frontend
+# runs separately (e.g. a native/mobile app, or you start the web app yourself).
+# For a fullstack repo that should start backend + frontend together and kill both
+# on exit, use the dev-fullstack template instead.
+#
+# Env overrides: DATABASE_URL, PORT, APP_DATABASE, APP_PG_PORT.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/_common.sh"
+
+if [ -z "${DATABASE_URL:-}" ]; then
+  ensure_postgres
+  DATABASE_URL="$(app_database_url)"
+fi
+
+PORT="$(app_pick_port)"
+
+echo "Backend:      http://localhost:${PORT}" >&2
+echo "DATABASE_URL: ${DATABASE_URL}" >&2
+
+cd "$(app_server_dir)"
+exec env DATABASE_URL="$DATABASE_URL" PORT="$PORT" bun run dev

--- a/skills/agent-dev-workflow/references/bin/dev-fullstack
+++ b/skills/agent-dev-workflow/references/bin/dev-fullstack
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# FULLSTACK variant: start backend + frontend together, kill both on exit.
+# Save as `bin/dev` in a repo where one command should run the whole stack
+# (e.g. Fastify + Vite). Picks a free port for each so concurrent worktrees
+# don't collide. Requires app_pick_vite_port() in _common.sh (see below).
+#
+# Env overrides: DATABASE_URL, PORT, VITE_PORT, HOST, APP_DATABASE, APP_PG_PORT.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/_common.sh"
+
+root="$(app_root)"
+
+if [ -z "${DATABASE_URL:-}" ]; then
+  ensure_postgres
+  DATABASE_URL="$(app_database_url)"
+fi
+
+PORT="$(app_pick_port)"
+VITE_PORT="$(app_pick_vite_port)"   # add this picker to _common.sh (range e.g. 4100-4199)
+
+echo "Frontend: http://localhost:${VITE_PORT}" >&2
+echo "Backend:  http://localhost:${PORT}" >&2
+
+# PID file so bin/cleanup can stop this session's whole process group.
+pidfile="$root/.dev.pid"
+echo $$ > "$pidfile"
+
+# kill 0 signals the whole process group → both children die when this script exits.
+trap 'rm -f "$pidfile"; kill 0' EXIT
+
+# Backend
+env DATABASE_URL="$DATABASE_URL" PORT="$PORT" HOST="${HOST:-0.0.0.0}" \
+  bash -c 'cd "$0"/<server-subdir> && bun run dev' "$root" &
+
+# Frontend — proxy to the actual backend port (important for non-default worktree ports).
+(cd "$root/<web-subdir>" && API_TARGET="http://localhost:${PORT}" VITE_PORT="$VITE_PORT" bun run dev) &
+
+wait

--- a/skills/agent-dev-workflow/references/bin/reset-db
+++ b/skills/agent-dev-workflow/references/bin/reset-db
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Drop and recreate this context's database, then migrate (+ seed if the project seeds).
+#
+# Env overrides: APP_DATABASE, APP_PG_PORT.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/_common.sh"
+
+ensure_postgres
+db="$(app_db_name)"
+app_recreate_db "$db"
+app_migrate "$(app_database_url)"
+# Seeds, if any: app_psql -d "$db" < "$(app_server_dir)/seed.sql" >/dev/null 2>&1
+echo "Database ${db} reset complete" >&2

--- a/skills/agent-dev-workflow/references/bin/setup
+++ b/skills/agent-dev-workflow/references/bin/setup
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Ensure postgres + this context's database + deps + migrations. One-command
+# onboarding for a fresh checkout or worktree.
+#
+# Usage:
+#   bin/setup                       # empty DB + migrations (+ seed, if project seeds)
+#   bin/setup path/to/snapshot.sql  # load a snapshot first (see snapshots.md)
+#   bin/setup gs://bucket/x.sql     # load a GCS snapshot first (see snapshots.md)
+#
+# Status → stderr; machine-parseable env (KEY=VALUE) → stdout for orchestrators.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/_common.sh"
+
+snapshot="${1:-}"
+if [ -n "$snapshot" ] && [[ "$snapshot" != gs://* ]] && [ ! -f "$snapshot" ]; then
+  echo "ERROR: snapshot not found: $snapshot" >&2
+  exit 1
+fi
+
+echo "Installing tool versions (asdf)..." >&2
+(cd "$(app_root)" && asdf install) >&2 || echo "asdf install skipped/failed — continuing" >&2
+
+ensure_postgres
+
+db="$(app_db_name)"
+# A snapshot load wants a clean DB; otherwise just ensure it exists (preserve data).
+if [ -n "$snapshot" ]; then
+  app_recreate_db "$db"
+else
+  app_ensure_db "$db"
+fi
+
+if [ ! -d "$(app_server_dir)/node_modules" ]; then
+  echo "Installing dependencies..." >&2
+  (cd "$(app_server_dir)" && bun install --frozen-lockfile) >&2
+fi
+
+url="$(app_database_url)"
+if [ -n "$snapshot" ]; then
+  echo "Loading snapshot: ${snapshot}..." >&2
+  if [[ "$snapshot" == gs://* ]]; then
+    gcloud storage cat "$snapshot" | strip_cloudsql | app_psql -d "$db" >/dev/null 2>&1
+  else
+    strip_cloudsql < "$snapshot" | app_psql -d "$db" >/dev/null 2>&1
+  fi
+fi
+
+app_migrate "$url"
+
+# If the project has seeds, run them on a fresh (non-snapshot) DB. See migrations-and-seeds.md.
+# [ -z "$snapshot" ] && app_psql -d "$db" < "$(app_server_dir)/seed.sql" >/dev/null 2>&1
+
+echo "DATABASE_URL=${url}"
+echo "APP_DATABASE=${db}"
+echo "PORT=$(app_pick_port)"

--- a/skills/agent-dev-workflow/references/bin/test
+++ b/skills/agent-dev-workflow/references/bin/test
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Run the backend test suite against a DEDICATED test database (app_test), never
+# the dev database. Ensures the DB exists + is migrated, then runs the suite.
+#
+# Pair this with a test-runner preload so a bare `bun test` (no bin/) is ALSO
+# safe — see test-isolation.md. That preload is what makes this robust; this
+# script is the ergonomic entry point.
+#
+# Usage: bin/test [args forwarded to the test runner]
+# Env overrides: APP_PG_PORT.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/_common.sh"
+
+ensure_postgres
+
+export APP_DATABASE="app_test"     # force the test DB regardless of worktree
+db="$(app_db_name)"
+url="$(app_database_url)"
+
+app_ensure_db "$db"
+app_migrate "$url"
+
+cd "$(app_server_dir)"
+exec env DATABASE_URL="$url" bun test "$@"

--- a/skills/agent-dev-workflow/references/gotchas.md
+++ b/skills/agent-dev-workflow/references/gotchas.md
@@ -1,0 +1,71 @@
+# Gotchas — the bugs every implementation re-derives if not warned
+
+These are real failures hit while building this pattern across projects. Each one
+costs an hour of debugging if you don't know it up front.
+
+## `ss` doesn't exist on macOS — and fails silently
+
+The single worst one. A naive port check uses `ss -tlnp` (Linux). On macOS `ss`
+isn't installed, the command fails, `2>/dev/null` swallows the error, the grep
+matches nothing → **every port reads "free"** → every concurrent worktree picks
+the *same* port and they collide. It looks like the port logic is broken; really
+the detector is no-op'ing.
+
+Fix (already in the `_common.sh` template): branch on the tool.
+
+```bash
+port_in_use() {
+  if command -v lsof &>/dev/null; then
+    lsof -iTCP:"$1" -sTCP:LISTEN -P -n &>/dev/null   # macOS + most Linux
+  elif command -v ss &>/dev/null; then
+    ss -tlnp 2>/dev/null | grep -q ":$1 "            # Linux without lsof
+  else
+    return 0                                          # unknown → assume in use
+  fi
+}
+```
+
+Also: **always scan from the default port**, not from `default+1` for worktrees.
+If a worktree starts scanning at 4001, it skips a free 4000. Reuse the canonical
+port whenever it's actually free; let real listen-state — not worktree identity —
+decide collisions.
+
+## postgres:18 changed the data directory layout
+
+On `postgres:18` the volume must mount at `/var/lib/postgresql`, **not**
+`/var/lib/postgresql/data` (the path used through 17). Mount the wrong one and the
+container's healthcheck never goes ready and `wait_for_postgres` times out after
+30s. If you pin `postgres:17-alpine` (the template default) use `…/data`; only
+change the mount if you deliberately move to 18.
+
+## docker-compose can't do per-context isolation — remove it
+
+If the repo had a `docker-compose.yml` just to template a local Postgres, **delete
+it** once these scripts exist. Compose pins one fixed DB name and one fixed host
+port — exactly what defeats per-worktree databases and ports. It also breaks in
+this workflow specifically: compose ties operations to the directory it was first
+run from, so when an agent worktree is deleted while its compose containers keep
+running, you can't manage them without recreating that exact path. The `bin/`
+scripts manage a path-independent shared container by name instead. Keeping both
+invites "which Postgres am I talking to?" confusion — pick the scripts.
+
+## `cd` inside a piped/exec'd script
+
+When a script needs to run a command in a subdir AND `exec`/background it with a
+specific env, `cd "$dir"` before the `exec` is cleaner than wrapping in
+`bash -c 'cd … && …'`. The single-service `dev` template does the former. The
+fullstack `dev` backgrounds two children, so it uses subshells `( cd … && … ) &`.
+
+## Container reuse vs. recreate
+
+`ensure_postgres` reuses a container that already exists (just `docker start`s it
+if stopped) and only creates one when absent. This is what lets many worktrees
+share one Postgres. Don't `docker run` unconditionally — you'll get a name clash
+or orphaned data. If you ever change Postgres image/version, you must `docker rm`
+the old container (and possibly the volume) once, deliberately.
+
+## md5 binary differs across platforms
+
+Linux/coreutils has `md5sum`; BSD/macOS has `md5 -q`. The `app_hash` helper
+branches on which exists so worktree DB names are stable on both. Don't hard-code
+`md5sum`.

--- a/skills/agent-dev-workflow/references/migrations-and-seeds.md
+++ b/skills/agent-dev-workflow/references/migrations-and-seeds.md
@@ -1,0 +1,59 @@
+# Migrations & seeds — the project-specific wiring
+
+`app_migrate()` in `_common.sh` is the one helper that's almost always
+project-specific. Everything else in the pattern is migration-tool-agnostic; this
+is where you adapt.
+
+## Migrations
+
+Set `app_migrate()` to however the project applies migrations. Two shapes seen
+across real projects:
+
+- **A package script** (simplest — reuse what `package.json` already defines):
+
+  ```bash
+  app_migrate() {
+    local url="$1"
+    echo "Running migrations..." >&2
+    (cd "$(app_server_dir)" && DATABASE_URL="$url" bun run db:migrate) >&2
+  }
+  ```
+
+  e.g. `db:migrate` → `drizzle-kit migrate`. The drizzle config reads
+  `DATABASE_URL` from env, so passing it through is enough.
+
+- **A migration runner script** (when there's a dedicated entrypoint):
+
+  ```bash
+  app_migrate() {
+    local url="$1"
+    echo "Running migrations..." >&2
+    DATABASE_URL="$url" bun run "$(app_server_dir)/src/db/run-migrations.ts" >&2
+  }
+  ```
+
+The **test preload** migrates in-process instead of shelling out (it's already in
+JS and wants no Docker dependency) — typically drizzle-orm's programmatic
+`migrate(drizzle(sql), { migrationsFolder })`. Both read the same migrations
+folder; they're two callers of one migration set, not two migration systems.
+
+Non-bun stacks: `alembic upgrade head` (Python), `rails db:migrate`,
+`migrate -path … up` (golang-migrate), etc. — same idea, swap the command.
+
+## Seeds (optional)
+
+Some projects seed reference/demo data on a fresh DB; many don't. If yours does,
+uncomment the seed lines in `setup`/`reset-db` and make seeds **idempotent**
+(`INSERT … ON CONFLICT DO NOTHING`) so re-running is safe. Crucially, **don't seed
+when loading a snapshot** (the snapshot already has data) and **don't seed the
+test DB** (suites set up their own fixtures). A common shape is one or more
+`seed*.sql` files run on a fresh non-snapshot DB, plus an optional local
+`.scratch/extra-seed.sql` for personal data; other projects keep seeding out of
+`bin/` entirely (a one-off script run on demand). Pick whichever fits.
+
+## A note on what NOT to put here
+
+Resist baking application-specific data setup into these scripts beyond a thin
+seed hook. The scripts manage the *database lifecycle*; rich fixture/demo data is
+the app's concern and tends to churn. Keep the boundary clean so the scripts stay
+portable across projects.

--- a/skills/agent-dev-workflow/references/orchestrator-integration.md
+++ b/skills/agent-dev-workflow/references/orchestrator-integration.md
@@ -1,0 +1,41 @@
+# Orchestrator integration (Conductor, etc.)
+
+The reason this pattern exists: AI agent orchestrators spin up a **separate git
+worktree per session** and let you register **setup / run / cleanup** commands.
+Many sessions run on one machine at once, so each needs its own database and port
+with zero manual config. These scripts provide exactly that contract.
+
+## The contract
+
+- **setup** → `bin/setup`. Idempotent: ensures the shared container, creates this
+  worktree's DB (derived from its path), installs deps, migrates. It **prints
+  `KEY=VALUE` env lines to stdout** (`DATABASE_URL`, `APP_DATABASE`, `PORT`, and
+  `VITE_PORT` for fullstack) and all human status to **stderr** — so an
+  orchestrator can capture stdout and inject those vars into the run step.
+- **run** → `bin/dev` (or `bin/server`). Picks the same free port and derives the
+  same DB, so it works whether or not the orchestrator threaded `setup`'s output
+  through. Uses `exec` for clean signal handling.
+- **cleanup** → `bin/cleanup`. Drops this worktree's DB (refuses the canonical
+  one without `--force`); stops the dev session if a fullstack `bin/dev` left a
+  PID file. Leaves the shared container up for other worktrees.
+
+## Why stdout/stderr discipline matters
+
+An orchestrator captures a script's stdout to learn where the service landed
+(`PORT=4002`). If status chatter ("Creating database…", "Running migrations…")
+goes to stdout too, it pollutes that capture. Rule: **machine-parseable env →
+stdout; everything humans read → stderr.** Every template here follows it.
+
+## Identity is the worktree path
+
+DB name and port both derive from the worktree, so two sessions never collide and
+re-running setup in the same worktree is a no-op-or-reset (not a duplicate).
+`git worktree list --porcelain | head -1` identifies the main worktree (canonical
+DB + default port); everything else is a hashed-path derivative. An orchestrator
+needs no per-session config — just register the three scripts once.
+
+## Override hooks
+
+Every derived value has an env override for when an orchestrator wants explicit
+control: `APP_DATABASE`, `APP_PG_PORT`, `PORT`, `VITE_PORT`. Honor these first in
+every script (the templates do).

--- a/skills/agent-dev-workflow/references/snapshots.md
+++ b/skills/agent-dev-workflow/references/snapshots.md
@@ -1,0 +1,59 @@
+# Production snapshots (optional — only if the project has a prod DB)
+
+Some projects want to load production-like data locally. This is **purely
+opt-in** and only makes sense once there's a production database to snapshot. A
+greenfield project (no prod yet) should skip all of this — adding it early is
+dead weight.
+
+Two scripts, both built on helpers already in `_common.sh`.
+
+## bin/snapshot — export prod → object storage
+
+For a GCP Cloud SQL prod instance, export server-side (no public IP / maintenance
+mode needed) to a bucket:
+
+```bash
+gcloud sql export sql "$INSTANCE" "gs://${BUCKET}/${filename}" \
+  --database="$DATABASE" --project="$PROJECT" --clean --if-exists --quiet
+```
+
+Cloud SQL refuses to overwrite an existing object, so `rm` it first. The Cloud
+SQL service account needs write access to the bucket (`roles/storage.objectAdmin`
+on the bucket, or reuse an existing tfstate/snapshots bucket). A bucket lifecycle
+rule (e.g. delete after 30 days) keeps snapshots from accumulating.
+
+## bin/load-snapshot — load a snapshot into this context's DB
+
+Accept a local path **or** a `gs://` URL (stream straight from the bucket — no
+local download). Drop → recreate → load → migrate:
+
+```bash
+snapshot="${1:-gs://${BUCKET}/latest.sql}"
+app_recreate_db "$(app_db_name)"
+if [[ "$snapshot" == gs://* ]]; then
+  gcloud storage cat "$snapshot" | strip_cloudsql | app_psql -d "$(app_db_name)"
+else
+  strip_cloudsql < "$snapshot" | app_psql -d "$(app_db_name)"
+fi
+app_migrate "$(app_database_url)"   # applies any migrations newer than the snapshot
+```
+
+`bin/setup <snapshot>` does the same in one step (see the setup template).
+
+## strip_cloudsql — why it exists
+
+Cloud SQL's `pg_dump` wrapper injects directives a vanilla local Postgres chokes
+on: `\restrict`/`\unrestrict` psql meta-commands and `GRANT … TO cloudsqlsuperuser`
+(a role that doesn't exist locally). Add this filter to `_common.sh` and pipe
+dumps through it on load:
+
+```bash
+strip_cloudsql() {
+  grep -v -E '^\\(restrict|unrestrict) |cloudsqlsuperuser'
+}
+```
+
+Non-GCP equivalents: AWS RDS → `aws rds ...` or `pg_dump` over the wire to S3;
+self-hosted → plain `pg_dump`. The shape is identical (export → object store →
+stream into `app_recreate_db` + load + migrate); only the export command and the
+provider-specific `strip_*` filter change.

--- a/skills/agent-dev-workflow/references/test-isolation.md
+++ b/skills/agent-dev-workflow/references/test-isolation.md
@@ -1,0 +1,91 @@
+# Test isolation — never let tests clobber dev data
+
+The single highest-value payoff of this pattern: **tests run against their own
+database (`app_test`), so a test suite's `truncate`/reset can never wipe the dev
+data you're demoing against.** `bin/test` handles this, but the robust fix is a
+**test-runner preload** so that even a bare `bun test` (someone forgetting `bin/`,
+or an IDE test button) is safe too.
+
+## The preload (bun example)
+
+`bunfig.toml`:
+
+```toml
+[test]
+preload = ["./test/setup.ts"]
+```
+
+`test/setup.ts` runs once before any test file. It must:
+
+1. Default `DATABASE_URL` to the test DB **with `??=`** — so an explicit env
+   (CI, or `bin/test` which `export`s it) always wins.
+2. Create the test DB if missing (connect to the maintenance `postgres` DB first).
+3. Migrate it to the current schema.
+
+```ts
+import postgres from 'postgres'
+import { drizzle } from 'drizzle-orm/postgres-js'
+import { migrate } from 'drizzle-orm/postgres-js/migrator'
+
+const DEFAULT_TEST_URL = 'postgres://app:app@localhost:5432/app_test'
+const usingDefault = process.env.DATABASE_URL === undefined
+
+process.env.DATABASE_URL ??= DEFAULT_TEST_URL
+process.env.JWT_SECRET ??= 'test-secret-min-32-chars-xxxxxxxxxxxxx'
+// ...other required env with ??=
+
+const url = process.env.DATABASE_URL
+
+// Create the DB only when we own the default (CI provides its own, already created).
+if (usingDefault) {
+  const dbName = new URL(url).pathname.slice(1)
+  const adminUrl = new URL(url); adminUrl.pathname = '/postgres'
+  const admin = postgres(adminUrl.toString(), { max: 1 })
+  try {
+    const rows = await admin`SELECT 1 FROM pg_database WHERE datname = ${dbName}`
+    if (rows.length === 0) await admin.unsafe(`CREATE DATABASE ${dbName}`)
+  } finally { await admin.end({ timeout: 5 }) }
+}
+
+const sql = postgres(url, { max: 1 })
+try { await migrate(drizzle(sql), { migrationsFolder: './migrations' }) }
+finally { await sql.end({ timeout: 5 }) }
+```
+
+Then delete the per-file `process.env.DATABASE_URL = …` lines from each test —
+the preload centralizes them. Keep any per-suite *override* (e.g. a suite that
+sets `MIN_SUPPORTED_BUILD=500` to exercise a code path) — just drop the shared DB/secret defaults.
+
+## Why `??=` and not `=`
+
+`??=` only fills in a default when nothing was provided. CI sets `DATABASE_URL`
+explicitly to its ephemeral service-container DB and migrates that itself, so the
+preload must defer to it. Using `=` would override CI and break it.
+
+## CI stays untouched
+
+CI already points at a throwaway service-container DB via an explicit
+`DATABASE_URL` and runs its own migrate step. This whole pattern is a **local-dev**
+change — verify CI is green after adding the preload, but you should not need to
+edit the CI workflow.
+
+## Residual footgun to document, not over-engineer
+
+If a dev copies `.env.example` → `.env` with `DATABASE_URL=…/app` (the dev DB),
+the test runner auto-loads `.env` and a *bare* `bun test` would defer to it
+(the preload uses `??=`). `bin/test` is immune (it `export`s the test URL, which
+beats `.env`). Don't try to guard by DB *name* — CI's throwaway DB may legitimately
+share the dev name. Just tell people: prefer `bin/test`.
+
+## Verifying it actually works (do this once)
+
+Seed a sentinel row into the dev DB, run the suite both ways, confirm it survived:
+
+```bash
+bin/db "INSERT INTO <some_table> (...) VALUES ('SENTINEL — do not delete', ...)"
+bin/test                                   # and: (cd <server> && bun test)
+bin/db "SELECT count(*) FROM <some_table> WHERE ... LIKE 'SENTINEL%'"  # → still 1
+```
+
+Other runners: pytest → a `conftest.py` fixture; vitest → `globalSetup`. Same
+three responsibilities (default env, ensure DB, migrate).


### PR DESCRIPTION
A reusable skill for standing up an **agent-friendly local dev workflow** on any Postgres-backed project: a `bin/` task-runner (inspired by GitHub's scripts-to-rule-them-all) over a **shared Postgres container** that gives each git worktree its **own isolated database + port**, plus a **dedicated test database** so tests never clobber dev data. This is the contract AI agent orchestrators (Conductor and similar) want — register `setup`/`run`/`cleanup` once and every session gets an isolated environment.

## Derived from three real implementations
Built by reading the actual `bin/` setups in **jarvus-hq**, **transit-lake**, and **SquadQuest** and separating:
- **Invariant** (copy verbatim, swap the prefix): worktree-aware DB naming, shared-container management, macOS-safe port picking, the stdout=env / stderr=status orchestrator contract.
- **Project-specific** (the knobs): prefix + PG constants, `app_server_dir` (single-package vs monorepo), `app_migrate` (the one migration-tool-specific helper), single-service vs fullstack `dev`, seeds, prod snapshots.

## Contents
- `SKILL.md` (104 lines) — the invariant/project-specific split, build order, verification steps, guardrails.
- `references/bin/` — all 8 script templates with a neutral `app`/`APP_` prefix; every one `bash -n` clean. Includes both single-service `dev` and a `dev-fullstack` variant.
- `references/` — `test-isolation` (the test-DB preload), `migrations-and-seeds`, `gotchas`, `snapshots`, `orchestrator-integration`.

## Hard-won bugs baked into gotchas.md
The silent failures every fresh implementation re-derives: **`ss` doesn't exist on macOS and fails silently** (→ every port reads "free" → concurrent worktrees collide), the **postgres:18 volume-path** change, **docker-compose removal** (can't do per-worktree DBs/ports), and **md5 portability**.

Verified the templates reproduce what's shipped in SquadQuest (`port_in_use` byte-identical; `pick_port` logic identical modulo formatting).

🤖 Generated with [Claude Code](https://claude.com/claude-code)