### PR TITLE
fix(release-flow): repair YAML parse error in frontmatter

### DIFF
--- a/skills/release-flow/SKILL.md
+++ b/skills/release-flow/SKILL.md
@@ -1,6 +1,16 @@
 ---
 name: release-flow
-description: Cut a release in a repo that uses the Jarvus develop→main Release-PR automation (the JarvusInnovations/infra-components release-prepare/validate/publish GitHub Actions). Use this whenever you're shipping merged work to production, drafting or editing a "Release: vX.Y.Z" PR, deciding a version bump, writing release notes/changelog, or the user says "ship it", "cut a release", "publish", "do the release", "merge the release PR", or "release notes". Also use it the moment you notice a repo has `.github/workflows/release-prepare.yml` (or release-publish/release-validate) or an open PR titled "Release: v*" — that's the signal this workflow is in effect. Covers: pushing develop to open the Release PR, pulling the bot-generated changelog, sorting commits into Improvements vs Technical, recommending semver bump, and merging to publish.
+description: >-
+  Cut a release in a repo that uses the Jarvus develop→main Release-PR automation
+  (the JarvusInnovations/infra-components release-prepare/validate/publish GitHub Actions).
+  Use this whenever you're shipping merged work to production, drafting or editing a
+  "Release: vX.Y.Z" PR, deciding a version bump, writing release notes/changelog, or the
+  user says "ship it", "cut a release", "publish", "do the release", "merge the release PR",
+  or "release notes". Also use it the moment you notice a repo has
+  `.github/workflows/release-prepare.yml` (or release-publish/release-validate) or an open
+  PR titled "Release: v*" — that's the signal this workflow is in effect. Covers: pushing
+  develop to open the Release PR, pulling the bot-generated changelog, sorting commits into
+  Improvements vs Technical, recommending semver bump, and merging to publish.
 ---
 
 # Release flow (develop → main, automated Release PR)


### PR DESCRIPTION
## Summary

The `release-flow` skill's frontmatter failed to parse as YAML. The `description` was an unquoted plain scalar containing colon-space sequences (`"Release: vX.Y.Z"`, `Covers: pushing`), which YAML reads as key/value separators.

Converted the value to a folded block scalar (`>-`) so colons and quotes need no escaping; the wrapped lines fold back into a single space-joined string.

## Test plan

- Parsed the frontmatter with PyYAML: `keys: ['name', 'description']` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)