### PR TITLE
feat(ci-quality-gates): global skill for pre-merge CI quality gates

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ npx skills add JarvusInnovations/agent-skills --skill <name>
 npx skills add --global JarvusInnovations/agent-skills --skill <name>
 ```
 
+- [`ci-quality-gates`](skills/ci-quality-gates/README.md) — Stand up the pre-merge CI quality gates: asdf provisioning + caching, the `lint`/`format:check`/`typecheck`/`test` script contract, and the house linters (oxlint + oxfmt, ruff, tofu fmt/validate). You reach for it to *bootstrap* a repo's CI before code lands on develop.
 - [`agent-dev-workflow`](skills/agent-dev-workflow/README.md) — Agent-friendly local dev: a `bin/` task-runner, worktree-isolated Postgres databases + ports, and a dedicated test DB. You reach for it to *bootstrap* a project's dev workflow.
 - [`release-flow`](skills/release-flow/README.md) — Cut releases via the develop→main Release-PR automation (infra-components `release-prepare`/`validate`/`publish`). *Ambient* across the many repos Jarvus ships, most of which won't have it installed locally.
 - [`axi-skills`](skills/axi-skills/README.md) — Bake an AXI CLI (`axi-sdk-js`) into a skill — committed `.mjs` bundle, shim, SessionStart hooks, SKILL.md generation, CI drift gate. The packaging companion to the upstream `axi` skill; used while *building* tooling.

--- a/skills/backend-fastify/SKILL.md
+++ b/skills/backend-fastify/SKILL.md
@@ -216,3 +216,44 @@ backend/
 - **No build step**: Bun runs the source; `tsc` is `--noEmit` for type checking only
 - **Path normalization**: Centralize path utilities, handle root '/' as special case
 - **Package management**: Use `bun add <pkg>` not manual `package.json` edits
+
+## CI & Code Quality
+
+Wire lint, format, and type-check into CI from the start. The cross-cutting setup (asdf
+provisioning + caching, path-filtered workflows, lockfile-frozen installs, the GitHub Actions
+templates) lives in the **`ci-quality-gates`** skill; this section is the Fastify-stack
+specifics that plug into it.
+
+**Linter + formatter: oxlint + oxfmt** (the Jarvus standard — not eslint/prettier):
+
+```bash
+bun add -d oxlint oxfmt
+```
+
+**The script contract.** Expose the same four scripts every Jarvus TS package does, so CI
+just calls `bun run <name>`:
+
+```jsonc
+{
+  "scripts": {
+    "dev":          "bun --watch src/index.ts",
+    "start":        "bun run src/index.ts",
+    "typecheck":    "tsc --noEmit",      // note: this stack's older docs called this `check`
+    "lint":         "oxlint index.ts src",
+    "format":       "oxfmt index.ts src",
+    "format:check": "oxfmt --check index.ts src",
+    "test":         "bun test"
+  }
+}
+```
+
+Use the **base** oxc config (`references/templates/oxlintrc.base.json` from `ci-quality-gates`,
+correctness=error) as the service's `.oxlintrc.json` — backend code doesn't need the React
+tier. In a Bun-workspaces monorepo, put the base config at the repo root as
+`.oxlintrc.base.json` and have each package extend it; a service that contains a UI subfolder
+adds `"ignorePatterns": ["ui"]` so the UI is linted by its own config.
+
+**CI workflow.** A single service uses one `ts-lint`-style job (`lint` + `format:check` +
+`typecheck`) plus a `test` job; a monorepo uses the per-package matrix in `ci-quality-gates`'s
+`lint.yml` / `test.yml`. All provisioned by the shared `setup-asdf` composite. Type-check is a
+required gate — `tsc --noEmit` catches bugs no linter does.

--- a/skills/ci-quality-gates/README.md
+++ b/skills/ci-quality-gates/README.md
@@ -1,0 +1,44 @@
+# ci-quality-gates
+
+Stands up the **pre-merge CI quality gates** a repo runs before code lands on `develop`:
+the toolchain provisioning, then **lint + format-check + type-check + test**, using Jarvus's
+standard linters — **oxlint + oxfmt** for TypeScript, **ruff** for Python, **tofu fmt/validate**
+for infrastructure.
+
+The reusable core is the *gate harness* — asdf provisioning + caching, the `lint` /
+`format:check` / `typecheck` script contract, path-filtered workflows, lockfile-frozen installs.
+Linting is one tier that rides on it, next to type-check and test.
+
+## When you'd want it
+
+Reach for it whenever a repo needs its checks set up or tightened:
+
+- **standing up CI on a new repo** — get the whole gate by default instead of re-deciding,
+- **a repo runs tests but no linter** (the portfolio's most common gap), or ships a Vite-default
+  eslint you want to swap for the house oxc setup,
+- **choosing/standardizing linters** so every repo uses the same tools and script names,
+- **CI that re-installs tools slowly** — the cached asdf composite fixes that.
+
+It deliberately **stops at the merge line**. Release-PR automation is `release-flow`; container
+build/publish and deploy belong to per-stack build docs and the `sysadmin`/deploy skills;
+credentialed checks (`tofu plan`, integration tests) are a separate later gate.
+
+## What it gives the agent
+
+- a one-place **provisioning composite action** (asdf + cache + reshim) to call from every job,
+- copy-ready **GitHub Actions** templates (`lint`, `test`, `ui-checks`, `tf-validate`),
+- the **oxlint/oxfmt** configs (base + stricter React) and the **ruff** rule block,
+- the **TS script contract** and the one-time **adoption migration** recipe so an existing repo
+  goes green on the gate's first run.
+
+## Install
+
+**Recommended scope: global.** You reach for this to *bootstrap* a repo's CI — often before it
+has any skills wired up — so it's most useful installed once for all your projects.
+
+```bash
+npx skills add --global JarvusInnovations/agent-skills --skill ci-quality-gates
+```
+
+Then ask your agent to set up the quality gates. See `SKILL.md` for the build order and
+`references/` for the provisioning and tool-standards deep dives.

--- a/skills/ci-quality-gates/SKILL.md
+++ b/skills/ci-quality-gates/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: ci-quality-gates
+description: Stand up the pre-merge CI quality gates a repo runs before code lands on develop — tool provisioning (asdf + .tool-versions + cache), lockfile-frozen installs, path-filtered GitHub Actions, and the lint / format:check / typecheck / test gate set with Jarvus's standard linters (oxlint + oxfmt for TypeScript, ruff for Python, tofu fmt/validate for IaC). Use when setting up CI for a new repo, adding a lint/format/type-check/test gate to an existing one, wiring GitHub Actions for code quality, choosing or standardizing linters/formatters, fixing CI that re-installs tools slowly, or noticing a repo runs tests but no linter. Scope stops at merge — Release-PR automation belongs to release-flow; build/publish/deploy to per-stack build + deploy skills. Triggers: "set up CI", "add linting/CI", "GitHub Actions checks", "oxlint", "oxfmt", "ruff", "format check", "type-check in CI", "quality gate", "lint isn't running in CI", "asdf in CI".
+---
+
+# CI quality gates (pre-merge checks)
+
+Sets up the checks that gate a pull request **before it merges to `develop`**:
+the toolchain provisioning, then lint + format-check + type-check + test, with
+Jarvus's standard linters. The reusable core is *the gate harness* — provisioning,
+the script contract, path filters, lockfile-frozen installs — and linting is one
+tier that rides on it next to type-check and test.
+
+The portfolio's actual failure mode isn't picking the wrong linter; it's repos
+that ship **no linter at all** (tests + type-check only, or build + test only).
+This skill exists so a new repo gets the whole gate by default instead of
+re-deciding — or skipping it.
+
+## Scope: what's in, what's out
+
+| In scope (gates a PR before merge) | Out of scope (hand off) |
+|---|---|
+| asdf provisioning + tool caching | Release-PR automation → **`release-flow`** |
+| lint, format-check, type-check, test | Container build / image publish → per-stack build docs |
+| IaC `fmt` + `validate` (credential-free) | Deploy / `tofu apply` → **`sysadmin`** / deploy skill |
+| docs `build --strict` (optional) | `tofu plan` & integration tests needing secrets (later gate) |
+
+One-sentence charter: **how a repo gates a PR before it merges.** If credentials
+or a release tag are involved, it's a different skill.
+
+## The two reference deep-dives
+
+| File | Read when |
+|---|---|
+| [provisioning.md](references/provisioning.md) | the CI harness — asdf + cache composite, lockfile-frozen installs, path filters, credential-free principle, private-dep git rewrite |
+| [tool-standards.md](references/tool-standards.md) | the linters/formatters — the TS script contract, oxc + ruff configs, the `check`→`typecheck` naming note, pre-commit's optional role, the one-time adoption migration |
+
+## The gate set
+
+| Gate | TypeScript | Python | IaC |
+|---|---|---|---|
+| Lint | `oxlint` | `ruff check` | — |
+| Format | `oxfmt --check` | `ruff format --check` | `tofu fmt -check` |
+| Types | `tsc --noEmit` | `mypy` (optional) | `tofu validate -backend=false` |
+| Test | `bun test` | `pytest` | — |
+
+All four TS gates are invoked through a fixed **script contract** —
+`lint` / `format` / `format:check` / `typecheck` — so the workflow is identical
+across packages and only calls `bun run <name>`. Details + the naming caveat in
+[tool-standards.md](references/tool-standards.md).
+
+## The universal harness (don't reinvent it)
+
+Every job, every language, shares the same provisioning. Consolidate it into one
+local composite action and call it after checkout:
+
+```yaml
+steps:
+  - uses: actions/checkout@v6
+  - uses: ./.github/actions/setup-asdf   # asdf + cache + reshim, one place
+```
+
+Plus three rules that make CI reproducible and cheap (full rationale in
+[provisioning.md](references/provisioning.md)):
+
+- **`.tool-versions` is the only place tool versions live** — local dev and CI
+  read the same file, so they can't drift.
+- **Lockfiles committed; CI installs frozen** — `bun install --frozen-lockfile`,
+  `uv run --frozen …`. A PR can't pass against unrecorded dependency versions.
+- **Path-filtered triggers** — each workflow fires only on its domain (and on
+  edits to itself).
+- **Credential-free** — lint/format/type-check/validate/hermetic-tests need no
+  secrets, so they run on fork PRs and start instantly.
+
+## Templates
+
+`references/templates/` — copy and adapt (each carries `# ADAPT:` markers):
+
+| Template | Drop at | Purpose |
+|---|---|---|
+| `github-actions/setup-asdf/action.yml` | `.github/actions/setup-asdf/action.yml` | the shared provisioning composite |
+| `github-actions/lint.yml` | `.github/workflows/lint.yml` | ruff + oxc/tsc lint gate (per-package matrix) |
+| `github-actions/test.yml` | `.github/workflows/test.yml` | pytest + bun test gate |
+| `github-actions/ui-checks.yml` | `.github/workflows/ui-checks.yml` | single-package frontend lint+fmt+types |
+| `github-actions/tf-validate.yml` | `.github/workflows/tf-validate.yml` | OpenTofu fmt + validate |
+| `oxlintrc.base.json` | `.oxlintrc.json` (or root `.oxlintrc.base.json` in a monorepo) | TS lint config — correctness=error |
+| `oxlintrc.react.json` | `<ui>/.oxlintrc.json` | stricter React/UI lint config |
+| `ruff.pyproject.toml` | append to `pyproject.toml` | ruff rule set |
+| `vscode-extensions.json` | `.vscode/extensions.json` | recommend oxc-vscode for local feedback |
+
+## Build order
+
+1. **Read [provisioning.md](references/provisioning.md) and
+   [tool-standards.md](references/tool-standards.md) first.** They carry the
+   rationale and the gotchas (reshim-after-cache, the script-name divergence).
+2. **Confirm `.tool-versions` exists** and pins everything CI needs (bun, uv,
+   python, opentofu — whatever applies). If not, set it via `asdf set …` first.
+3. **Drop the composite action** at `.github/actions/setup-asdf/action.yml`.
+4. **Add per-language config + scripts:** oxc configs + the four `package.json`
+   scripts for TS; the ruff block + `uv add --dev ruff` for Python.
+5. **Add the workflows you need**, delete the jobs you don't, fix the `paths:`
+   and `working-directory:` to the repo's real layout.
+6. **For an existing repo, land the one-time format/lint-fix as a separate commit
+   *before* the workflow commit** (see the migration section in
+   [tool-standards.md](references/tool-standards.md)) so the gate goes green on
+   its first run.
+7. **Commit `.vscode/extensions.json`** so local editors match CI.
+8. **Verify**: open a PR (or push a branch) and confirm each gate runs, is
+   green, and a deliberate violation actually fails it. Don't assume — a
+   mis-filtered `paths:` silently skips the gate, which reads as "passing".
+
+## Guardrails
+
+- **Don't let the gate need secrets.** The moment a "lint" job wants cloud
+  credentials, it's the wrong job — split the credentialed check into its own
+  later workflow. Keep this set fork-safe and instant.
+- **One linter + one formatter per language.** oxc for TS, ruff for Python. Don't
+  add eslint/prettier/biome/black alongside — that's the sprawl this replaces. A
+  Vite scaffold ships a default eslint; remove it when adopting oxc.
+- **Type-check is a gate, not a nicety.** `tsc --noEmit` / strict mode catches
+  bugs no linter does — keep it required.
+- **Pre-commit is optional, not the gate.** CI is the source of truth; the IDE is
+  local feedback. Only reach for a `.pre-commit-config.yaml` on multi-linter
+  Python repos (ruff + sqlfluff + markdown + …). See
+  [tool-standards.md](references/tool-standards.md).
+- **Stay before the merge line.** Release, build, publish, deploy, and
+  credentialed plans belong to other skills. If you're editing
+  `release-prepare.yml` or a deploy workflow, you're in the wrong skill.

--- a/skills/ci-quality-gates/references/provisioning.md
+++ b/skills/ci-quality-gates/references/provisioning.md
@@ -1,0 +1,93 @@
+# Provisioning, caching, and the CI harness
+
+The part of the gate that's identical across every Jarvus repo regardless of
+language. Get this right once and lint/test/type-check all ride on it.
+
+## asdf is the single source of tool versions
+
+Every repo already pins its toolchain in `.tool-versions` for local dev (Bun,
+uv, Python, OpenTofu, …). CI reads the **same file** — there is no second place
+where versions live, so local and CI can't drift.
+
+```
+# .tool-versions  (example)
+bun 1.3.11
+uv 0.10.12
+python 3.12.13
+opentofu 1.11.5
+```
+
+## The composite action (use this, don't copy-paste the block)
+
+The provisioning steps repeat in every job. continuous-gtfs currently inlines
+them ~6 times across `lint.yml` / `test.yml` / `ui-checks.yml`; that's the proven
+behavior but it rots. Consolidate into one local composite action and call it:
+
+```yaml
+steps:
+  - uses: actions/checkout@v6
+  - uses: ./.github/actions/setup-asdf   # the whole provisioning block
+```
+
+Drop `templates/github-actions/setup-asdf/action.yml` at
+`.github/actions/setup-asdf/action.yml`. It does four things:
+
+1. **`asdf-vm/actions/setup@v4`** — installs asdf itself.
+2. **`actions/cache@v5`** keyed on `hashFiles('.tool-versions')` — restores the
+   installed tools. The `restore-keys: asdf-tools-` prefix lets a changed
+   `.tool-versions` warm-start from the previous cache instead of a cold install.
+3. **`asdf-vm/actions/install@v4`** *only on cache miss* — the slow path,
+   skipped on the ~1-minute-saving cache hit.
+4. **`asdf reshim`** — regenerates shims so the cached tools are resolvable in
+   later steps. Skipping this is the classic "command not found" after a cache
+   hit.
+
+`checkout` must come first so the local `./.github/actions/setup-asdf` path
+exists before it's referenced.
+
+## Reproducibility: lockfiles + frozen installs
+
+Commit `bun.lock` and `uv.lock`. CI installs from the lockfile and **fails if it
+would change**, so a PR can never pass against dependency versions that aren't
+recorded:
+
+- TS: `bun install --frozen-lockfile`
+- Python: `uv run --frozen <cmd>` (e.g. `uv run --frozen ruff check`)
+
+## Path-filtered triggers
+
+Each workflow fires only when its domain changes — and always includes its own
+file so edits to the workflow re-run it:
+
+```yaml
+on:
+  pull_request:
+    paths: ['pkg/**', '.github/workflows/lint.yml']
+  push:
+    branches: [develop]
+    paths: ['pkg/**', '.github/workflows/lint.yml']
+```
+
+In a monorepo, give each package its own paths (or a per-package matrix) so a
+front-end change doesn't run the Python gate and vice-versa.
+
+## Credential-free by design
+
+Lint, format-check, type-check, `tofu fmt`/`validate -backend=false`, and
+hermetic unit tests need **no secrets**. Keep them that way: they then run on
+fork PRs, start instantly (no WIF/cloud auth), and can't leak. Anything needing
+credentials (`tofu plan`, integration tests against real services, deploys) is a
+*different*, later gate — out of scope here (see SKILL.md boundary).
+
+The one exception: pulling a **private git dependency/module**. That needs a
+repo-scoped token, not cloud credentials — a `git config --global url.…insteadOf`
+rewrite (commented in `test.yml` / `tf-validate.yml`). It stays cheap and
+fork-safe-ish; just be aware forks won't have the secret.
+
+## What this deliberately is NOT
+
+- **No pre-commit framework as the gate.** CI is the gate; the IDE is the fast
+  local feedback loop (see `tool-standards.md`). Pre-commit is an optional extra
+  tier, not the source of truth — the flagship and newest repos skip it.
+- **No build/publish/deploy here.** Those belong to per-stack build docs and the
+  deploy/sysadmin skills. Release PR automation belongs to `release-flow`.

--- a/skills/ci-quality-gates/references/templates/github-actions/lint.yml
+++ b/skills/ci-quality-gates/references/templates/github-actions/lint.yml
@@ -1,0 +1,66 @@
+name: Lint
+
+# Pre-merge lint + format + type-check gate. Fast and credential-free: it never
+# needs cloud secrets, so it runs on every PR (including forks). Path filters keep
+# it from firing on unrelated changes; ADAPT the paths to your repo's layout.
+on:
+  pull_request:
+    paths:
+      - 'pkg/**'              # ADAPT: Python package dir(s)
+      - 'services/**'         # ADAPT: TS service/package dir(s)
+      - '.github/workflows/lint.yml'
+  push:
+    branches: [develop]
+    paths:
+      - 'pkg/**'
+      - 'services/**'
+      - '.github/workflows/lint.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  # --- Python (ruff). Delete this job if the repo has no Python. -------------
+  python-lint:
+    name: Ruff (pkg)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: pkg        # ADAPT: dir containing pyproject.toml
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-asdf
+      - name: Ruff lint
+        run: uv run --frozen ruff check
+      - name: Ruff format check
+        run: uv run --frozen ruff format --check
+
+  # --- TypeScript (oxc + tsc). Delete this job if the repo has no TS. --------
+  # Single-package repo: drop the matrix, set working-directory to the package,
+  # and inline the three steps. The matrix is for monorepos with several packages.
+  ts-lint:
+    name: oxc (${{ matrix.package }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - package: services/api          # ADAPT
+            typecheck: true
+          - package: services/worker        # ADAPT
+            typecheck: true
+    defaults:
+      run:
+        working-directory: ${{ matrix.package }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-asdf
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+      - name: Lint
+        run: bun run lint
+      - name: Check formatting
+        run: bun run format:check
+      - name: Type check
+        if: ${{ matrix.typecheck }}
+        run: bun run typecheck

--- a/skills/ci-quality-gates/references/templates/github-actions/setup-asdf/action.yml
+++ b/skills/ci-quality-gates/references/templates/github-actions/setup-asdf/action.yml
@@ -1,0 +1,32 @@
+name: Setup ASDF tools
+description: >-
+  Install and cache the project's asdf-managed toolchain from .tool-versions.
+  Drop this in at .github/actions/setup-asdf/ and call it with
+  `- uses: ./.github/actions/setup-asdf` right after actions/checkout. It is the
+  single source of the provisioning block every quality-gate job shares — cache
+  hit skips the install, and `asdf reshim` makes the freshly-cached shims
+  resolvable in later steps.
+runs:
+  using: composite
+  steps:
+    - name: Setup ASDF
+      uses: asdf-vm/actions/setup@v4
+
+    - name: Restore ASDF tools from cache
+      id: asdf-tools-cache
+      uses: actions/cache@v5
+      with:
+        key: asdf-tools-${{ hashFiles('.tool-versions') }}
+        restore-keys: |
+          asdf-tools-
+        path: |
+          ${{ env.ASDF_DIR }}/plugins
+          ${{ env.ASDF_DIR }}/installs
+
+    - name: Install ASDF tools on cache miss
+      if: ${{ steps.asdf-tools-cache.outputs.cache-hit != 'true' }}
+      uses: asdf-vm/actions/install@v4
+
+    - name: Reshim ASDF tools
+      shell: bash
+      run: asdf reshim

--- a/skills/ci-quality-gates/references/templates/github-actions/test.yml
+++ b/skills/ci-quality-gates/references/templates/github-actions/test.yml
@@ -1,0 +1,58 @@
+name: Tests
+
+# Test gate, kept separate from Lint so a failing test and a failing lint report
+# as distinct checks. Same provisioning + path-filter + lockfile-frozen recipe.
+on:
+  pull_request:
+    paths:
+      - 'pkg/**'              # ADAPT
+      - 'services/**'         # ADAPT
+      - '.github/workflows/test.yml'
+  push:
+    branches: [develop]
+    paths:
+      - 'pkg/**'
+      - 'services/**'
+      - '.github/workflows/test.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  # --- Python tests. Delete if no Python. -----------------------------------
+  python-tests:
+    name: Python tests
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: pkg          # ADAPT
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-asdf
+      # If the package pulls a private git dependency, uncomment — same git
+      # rewrite used by deploy workflows (needs a repo-scoped token secret):
+      # - name: Configure git for private dependency access
+      #   run: git config --global url."https://x-access-token:${{ secrets.BOT_GITHUB_TOKEN }}@github.com/".insteadOf "https://github.com/"
+      - name: Run pytest
+        run: uv run --frozen pytest -q
+
+  # --- TS tests. Delete if no TS. One job per package (matrix), or inline. ---
+  ts-tests:
+    name: Tests (${{ matrix.package }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - services/api          # ADAPT
+          - services/worker        # ADAPT
+    defaults:
+      run:
+        working-directory: ${{ matrix.package }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-asdf
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+      - name: Run bun test
+        run: bun test

--- a/skills/ci-quality-gates/references/templates/github-actions/tf-validate.yml
+++ b/skills/ci-quality-gates/references/templates/github-actions/tf-validate.yml
@@ -1,0 +1,46 @@
+name: TF Validate
+
+# Infrastructure-as-code gate for OpenTofu/Terraform. fmt + validate only — NOT
+# `tofu plan`, which needs cloud state/credentials. This stays credential-free so
+# it runs on every PR. (A separate, credential-bearing plan job is a later step,
+# once the config is modularized and you have WIF/secrets wired.)
+on:
+  pull_request:
+    paths:
+      - 'tf/**'
+      - '.github/workflows/tf-validate.yml'
+  push:
+    branches: [develop]
+    paths:
+      - 'tf/**'
+      - '.github/workflows/tf-validate.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  tf-validate:
+    name: Format + validate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-asdf
+
+      # fmt needs no providers/modules/credentials — run it first so a
+      # formatting nit fails fast before the slower init steps.
+      - name: Check formatting
+        run: tofu fmt -check -recursive tf/
+
+      # Uncomment if a module is pulled from a private git repo over https
+      # (repo-scoped token secret required):
+      # - name: Configure git for private module access
+      #   run: git config --global url."https://x-access-token:${{ secrets.BOT_GITHUB_TOKEN }}@github.com/".insteadOf "https://github.com/"
+
+      # validate needs providers + modules installed but no cloud/state access,
+      # so `-backend=false` keeps it credential-free. Repeat the block per root
+      # module (each self-contained module inits separately).
+      - name: Validate root module
+        working-directory: tf
+        run: |
+          tofu init -backend=false -input=false
+          tofu validate

--- a/skills/ci-quality-gates/references/templates/github-actions/ui-checks.yml
+++ b/skills/ci-quality-gates/references/templates/github-actions/ui-checks.yml
@@ -1,0 +1,37 @@
+name: UI Checks
+
+# Single-package frontend (e.g. a Vite + React app under app/ or ui/). Use this
+# instead of the ts-lint matrix when the front end is one package you want gated
+# on its own path. Lint + format + type-check in one job.
+on:
+  pull_request:
+    paths:
+      - 'ui/**'              # ADAPT: frontend package dir
+      - '.github/workflows/ui-checks.yml'
+  push:
+    branches: [develop]
+    paths:
+      - 'ui/**'
+      - '.github/workflows/ui-checks.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  checks:
+    name: Lint, format, type-check
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ui          # ADAPT
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-asdf
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+      - name: Lint
+        run: bun run lint
+      - name: Check formatting
+        run: bun run format:check
+      - name: Type check
+        run: bun run typecheck

--- a/skills/ci-quality-gates/references/templates/oxlintrc.base.json
+++ b/skills/ci-quality-gates/references/templates/oxlintrc.base.json
@@ -1,0 +1,9 @@
+{
+  "plugins": ["import", "typescript", "unicorn", "oxc"],
+  "categories": {
+    "correctness": "error"
+  },
+  "rules": {
+    "no-unused-vars": ["error", { "ignoreRestSiblings": true, "argsIgnorePattern": "^_", "varsIgnorePattern": "^_", "caughtErrorsIgnorePattern": "^_" }]
+  }
+}

--- a/skills/ci-quality-gates/references/templates/oxlintrc.react.json
+++ b/skills/ci-quality-gates/references/templates/oxlintrc.react.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "./node_modules/oxlint/configuration_schema.json",
+  "plugins": ["react", "import", "typescript", "unicorn", "oxc"],
+  "categories": {
+    "correctness": "error",
+    "suspicious": "error",
+    "perf": "error"
+  },
+  "rules": {
+    "react-hooks/rules-of-hooks": "error",
+    "react-hooks/exhaustive-deps": "error",
+    "react/react-compiler": "error",
+    "react/only-export-components": ["warn", { "allowConstantExport": true }],
+    "react/react-in-jsx-scope": "off",
+
+    "eqeqeq": ["error", "always", { "null": "ignore" }],
+    "curly": ["warn", "all"],
+    "no-use-before-define": ["error", { "functions": false, "classes": true }],
+    "require-unicode-regexp": "error",
+
+    "typescript/no-non-null-assertion": "warn",
+    "typescript/array-type": ["warn", { "default": "array" }],
+
+    "unicorn/filename-case": [
+      "warn",
+      { "cases": { "pascalCase": true, "camelCase": true, "kebabCase": true } }
+    ],
+    "unicorn/prefer-string-replace-all": "warn",
+
+    "sort-imports": ["warn", { "allowSeparatedGroups": true, "ignoreDeclarationSort": true }],
+    "import/no-duplicates": ["warn", { "prefer-inline": true }],
+    "import/consistent-type-specifier-style": ["warn", "prefer-inline"],
+    "import/first": "warn",
+    "import/newline-after-import": "warn",
+    "import/no-unassigned-import": "off"
+  }
+}

--- a/skills/ci-quality-gates/references/templates/ruff.pyproject.toml
+++ b/skills/ci-quality-gates/references/templates/ruff.pyproject.toml
@@ -1,0 +1,15 @@
+# Append to the package's pyproject.toml. Add ruff to the dev dependency group
+# with `uv add --dev ruff` (don't hand-edit the deps table).
+
+[tool.ruff]
+line-length = 88
+
+[tool.ruff.lint]
+# E  pycodestyle errors      F  pyflakes
+# I  isort (import order)    B  flake8-bugbear (likely bugs)
+# UP pyupgrade (modernize)
+select = ["E", "F", "I", "B", "UP"]
+
+# Exempt machine-generated files (protobuf, etc.) — they aren't hand-maintained.
+# [tool.ruff.lint.per-file-ignores]
+# "src/pkg/foo_pb2.py" = ["ALL"]

--- a/skills/ci-quality-gates/references/templates/vscode-extensions.json
+++ b/skills/ci-quality-gates/references/templates/vscode-extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["oxc.oxc-vscode"]
+}

--- a/skills/ci-quality-gates/references/tool-standards.md
+++ b/skills/ci-quality-gates/references/tool-standards.md
@@ -1,0 +1,122 @@
+# Tool standards: the linters, formatters, and the script contract
+
+What runs inside the gate. These are the Jarvus house choices — one linter and
+one formatter per language family, no eslint+prettier+biome+mypy sprawl. Adopt
+them so new repos stop re-deciding (the portfolio's real failure mode is repos
+that ship *no* linter at all).
+
+## The script contract (TypeScript)
+
+Every TS package exposes the **same four scripts**, so CI is stack-agnostic — it
+just calls `bun run <name>`:
+
+```jsonc
+{
+  "scripts": {
+    "lint":         "oxlint <paths>",          // e.g. "oxlint ." or "oxlint index.ts src"
+    "format":       "oxfmt <paths>",           // writes
+    "format:check": "oxfmt --check <paths>",   // CI uses this
+    "typecheck":    "tsc --noEmit"             // or "tsc -b" for project-references
+  }
+}
+```
+
+> **Naming note / known divergence.** The `backend-fastify` and `frontend-react`
+> stack skills currently document the type-check script as **`check`**
+> (`bun run check` → `tsc --noEmit`). The CI contract here standardizes on
+> **`typecheck`** (matching the continuous-gtfs flagship). When wiring CI, either
+> rename `check` → `typecheck` in the package (recommended, for cross-repo
+> uniformity) or change the workflow's type-check step to `bun run check`. Pick
+> one per repo and be consistent.
+
+Add the tools as dev deps (don't hand-edit `package.json`):
+
+```bash
+bun add -d oxlint oxfmt
+```
+
+## TypeScript: oxlint + oxfmt + tsc
+
+- **oxlint** — fast Rust linter. Config is `.oxlintrc.json`.
+  - **Single-package repo:** use `templates/oxlintrc.base.json` directly as the
+    package's `.oxlintrc.json`.
+  - **Monorepo:** put `templates/oxlintrc.base.json` at the repo root as
+    `.oxlintrc.base.json`, and give each package a tiny `.oxlintrc.json` that
+    extends it:
+
+    ```json
+    {
+      "$schema": "./node_modules/oxlint/configuration_schema.json",
+      "extends": ["../../.oxlintrc.base.json"]
+    }
+    ```
+
+    A server package that contains a UI subfolder ignores it so the UI is linted
+    by its own stricter config: add `"ignorePatterns": ["ui"]`.
+- **React/UI packages** get a stricter config — `templates/oxlintrc.react.json`
+  (adds the `suspicious` + `perf` categories, react-hooks, react-compiler, and
+  import-ordering rules). It's standalone (doesn't extend the base) because it
+  needs the `react` plugin and a different category set.
+- **oxfmt** — the formatter. CI runs `format:check`; developers run `format`.
+- **tsc** — type-check only, `--noEmit` (Bun runs the source; tsc never builds).
+  `strict: true` belongs in `tsconfig.json` — type-check *is* a gate, it catches
+  a whole class of bugs no linter does.
+
+**Philosophy: correctness-as-error, style-as-warn.** The base config sets the
+`correctness` category to `error` and little else — no opinionated style churn on
+the backend. The React config tightens to `error` for correctness/suspicious/perf
+and uses `warn` for stylistic/import-ordering rules. Formatting is oxfmt's job,
+not the linter's.
+
+## Python: ruff (+ uv)
+
+- **ruff** does both lint (`ruff check`) and format (`ruff format`) — it replaces
+  black + flake8 + isort + pyupgrade. No black.
+- Config block: `templates/ruff.pyproject.toml` → append to `pyproject.toml`.
+  Standard rule set `["E", "F", "I", "B", "UP"]`, line length 88. Exempt
+  generated files (protobuf, etc.) via `per-file-ignores`.
+- Add it with `uv add --dev ruff`. CI runs `uv run --frozen ruff check` and
+  `uv run --frozen ruff format --check`.
+- **mypy is optional.** Data/infra repos that want strict typing add
+  `uv add --dev mypy` and a `uv run mypy src/` step with `strict = true`. The
+  flagship pipeline skips it; reach for it when the type surface is worth it.
+
+## IaC: OpenTofu
+
+`tofu fmt -check -recursive` + `tofu init -backend=false && tofu validate` per
+root module. Format + config-validity only — never `tofu plan` in this gate
+(needs state/credentials). See `templates/github-actions/tf-validate.yml`.
+
+## Docs (optional)
+
+A docs site (mkdocs) gets a build gate: `mkdocs build --strict` so a broken link
+or missing nav entry fails the PR. Trigger on `docs/**` + `mkdocs.yml`.
+
+## IDE recommendation, not pre-commit
+
+Local fast feedback comes from the editor, not git hooks. Commit
+`templates/vscode-extensions.json` as `.vscode/extensions.json` to recommend the
+**oxc.oxc-vscode** extension (lint + format-on-save matching CI). For Python,
+ruff's editor integration plays the same role.
+
+**Pre-commit is an optional extra tier, not the gate.** The flagship
+(continuous-gtfs) and the newest repos deliberately run checks in CI + IDE and
+*skip* a pre-commit framework. Where it earns its keep is multi-linter Python
+repos that also lint SQL/markdown/notebooks (e.g. ruff + sqlfluff + markdownlint +
+nbstripout) — there a `.pre-commit-config.yaml` driven by `pre-commit/action` in
+CI consolidates many hooks. Don't add it to a plain TS or single-linter Python
+repo; it's friction without payoff there.
+
+## Adopting on an existing repo: the one-time migration
+
+Turning a gate on for the first time will surface findings. Land them as a
+**single mechanical commit** *before* the commit that adds the workflow, so the
+gate goes green on its first run and the diff stays legible:
+
+1. `bun run format && bun run lint --fix` (or `uv run ruff format && ruff check
+   --fix`) — commit as `style:` / `build:`.
+2. Hand-fix whatever `--fix` couldn't.
+3. Add the config files + scripts + workflow — commit as `ci:`.
+
+Don't batch the auto-format with feature work; reviewers can't see the real
+change underneath thousands of reformatted lines.

--- a/skills/frontend-react/SKILL.md
+++ b/skills/frontend-react/SKILL.md
@@ -138,3 +138,43 @@ src/
 - **shadcn is optional**: Only reach for `components/ui/` + `bunx shadcn@latest` when the
   project has opted into shadcn/ui (see [shadcn.md](references/shadcn.md)); otherwise build
   components by hand with Tailwind + `cn()`
+
+## CI & Code Quality
+
+Lint, format, and type-check are part of the stack, not an afterthought — wire them into
+CI from the start. The cross-cutting setup (asdf provisioning + caching, path-filtered
+workflows, lockfile-frozen installs, the GitHub Actions templates) lives in the
+**`ci-quality-gates`** skill; this section is just the React-stack specifics that plug into it.
+
+**Linter + formatter: oxc, not eslint/prettier.** A fresh Vite scaffold ships an eslint
+config — **remove it** and adopt **oxlint + oxfmt** (the Jarvus standard). Don't run both.
+
+```bash
+bun add -d oxlint oxfmt
+```
+
+**The script contract.** Expose the same four scripts every Jarvus TS package does, so CI
+just calls `bun run <name>`:
+
+```jsonc
+{
+  "scripts": {
+    "dev":          "vite",
+    "build":        "tsc -b && vite build",
+    "typecheck":    "tsc -b",            // note: this stack's older docs called this `check`
+    "lint":         "oxlint .",
+    "format":       "oxfmt .",
+    "format:check": "oxfmt --check ."
+  }
+}
+```
+
+A React app's `.oxlintrc.json` uses the **stricter React config** (suspicious + perf
+categories, react-hooks, react-compiler) — copy `references/templates/oxlintrc.react.json`
+from `ci-quality-gates`. Commit `.vscode/extensions.json` recommending `oxc.oxc-vscode` so
+format-on-save matches CI.
+
+**CI workflow.** Use the single-package `ui-checks.yml` template from `ci-quality-gates` —
+one job running `bun run lint`, `format:check`, and `typecheck`, provisioned by the shared
+`setup-asdf` composite. See that skill for the full build order and the one-time migration
+when turning the gate on for an existing app.

--- a/skills/mobile-flutter/SKILL.md
+++ b/skills/mobile-flutter/SKILL.md
@@ -216,3 +216,29 @@ context.go('/login');               // replace stack
 - **macOS entitlements**: Network requests need `com.apple.security.network.client`, keychain needs `keychain-access-groups` — both in `macos/Runner/DebugProfile.entitlements` and `Release.entitlements`
 - **macOS signing**: Set development team in Xcode (Runner target → Signing & Capabilities → Team → All configurations)
 - **Commit generated code separately**: After any command that generates/changes code, commit those changes with the exact command in the message BEFORE making manual edits
+
+## CI & Code Quality
+
+Wire analyze, format, and tests into CI from the start. The cross-cutting CI harness — asdf
+provisioning + caching, path-filtered workflows, the `setup-asdf` composite — lives in the
+**`ci-quality-gates`** skill; reuse it here. The *tools* differ from the TS/Python stacks:
+Dart ships its own analyzer and formatter, so there's no oxc/ruff here.
+
+**The gate (Dart-native):**
+
+| Gate | Command |
+|---|---|
+| Lint / analyze | `flutter analyze lib/ test/` |
+| Format check | `dart format --output=none --set-exit-if-changed lib/ test/` |
+| Test | `flutter test` |
+
+`flutter analyze` reads `analysis_options.yaml` — start from `package:flutter_lints` (and add
+`riverpod_lint` only if it doesn't clash with `drift_dev`'s analyzer version; see
+[gotchas.md](references/gotchas.md)). The companion `dart-run-static-analysis` skill (see
+**Companion Skills** above) drives `dart analyze` + `dart fix --apply` locally — the same gate,
+just in the dev loop.
+
+**Provisioning.** Flutter is pinned in `.tool-versions` (plus ruby/cocoapods for iOS), so the
+`setup-asdf` composite from `ci-quality-gates` provisions CI exactly as for the other stacks.
+Commit `pubspec.lock` and use `flutter pub get` (it respects the lock). The credential-free,
+path-filtered, IDE-over-pre-commit principles all carry over — only the tool commands change.


### PR DESCRIPTION
## What

Adds a new **global** skill, `ci-quality-gates`, and wires the three stack skills to it.

The skill codifies the **pre-merge CI quality gates** a repo runs before code lands on `develop` — the part that's identical across the portfolio (asdf provisioning + caching, lockfile-frozen installs, path-filtered workflows, the `lint`/`format:check`/`typecheck`/`test` script contract) plus the house tool standards (oxlint + oxfmt for TS, ruff for Python, tofu fmt/validate for IaC).

It's deliberately scoped to **stop at the merge line**: Release-PR automation stays with `release-flow`; container build/publish and deploy stay with the stack/`sysadmin` skills; credentialed checks (`tofu plan`, integration tests) are a separate later gate.

## Why

A survey of ~50 repos under `~/repos` found the provisioning layer already universal, but the *tool standard* (oxc + ruff) freshly minted and unevenly adopted — many recent repos ship **no linter at all** (tests + type-check only). The real failure mode is omission, not wrong-tool. This skill makes the full gate the default so new repos stop re-deciding (or skipping it), and pins the standard distilled from the `continuous-gtfs` flagship + `sound-transit-gtfs-pipeline`.

## Contents

- **`skills/ci-quality-gates/`** — `SKILL.md`, `README.md`, two reference deep-dives (`provisioning.md`, `tool-standards.md`), and copy-ready templates: a `setup-asdf` composite action, `lint`/`test`/`ui-checks`/`tf-validate` workflows, oxlint base + React configs, the ruff block, and `vscode-extensions.json`.
- **`frontend-react` / `backend-fastify` / `mobile-flutter`** — each gains a *CI & Code Quality* section naming its linters/scripts and deferring the harness to the new skill. `frontend-react` calls out swapping the Vite-default eslint for oxc; `mobile-flutter` uses Dart-native analyze/format/test.
- **README** — lists `ci-quality-gates` under the Global skills.

## Decision to confirm

Standardizes the TS type-check script name on **`typecheck`** (the stack skills' older docs used `check`), matching the flagship. Flagged inline in each skill — easy to flip back to `check` if preferred.

## Note

Skill drafted following the `skill-creator` anatomy (lean SKILL.md + progressive disclosure into `references/` + templates), but **the eval/benchmark loop was intentionally skipped** per request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QHVPQXzEiaPAupLgDa7D5n