### PR TITLE
refactor(agent-dev-workflow): cross-skill seam + port/seed/PG findings from 3 adopters

### DIFF
--- a/skills/agent-dev-workflow/SKILL.md
+++ b/skills/agent-dev-workflow/SKILL.md
@@ -49,30 +49,44 @@ know which parts you copy verbatim and which you adapt.
 - worktree-aware DB naming (`app_db_name`, `is_main_worktree`, `app_hash`)
 - shared-container management (`ensure_postgres`, `wait_for_postgres`, `app_psql`)
 - DB create/recreate helpers; the `setup`/`reset-db`/`db`/`cleanup`/`test` scripts
+  (keep these names — e.g. `db`, not `query` — so the muscle memory transfers across repos)
 - port picking (`port_in_use`, `find_available_port`, `app_pick_port`) — **including
   the macOS `lsof`/`ss` split; do not "simplify" it away** (see gotchas)
 - stdout=env / stderr=status discipline
 
 **Project-specific** (the knobs you set):
 
-- the prefix, PG user/password/image, container/volume names, default PG port
+- the prefix, PG user/password/image, container/volume names
+- the **base port band** — the default PG port plus the backend/frontend worktree
+  ranges. This is the project's claim on the machine: worktree isolation keeps a
+  project's *own* copies apart, but the base band is what keeps *different projects*
+  from colliding when several run at once. Pick a distinct, uncommon band per repo
+  (see gotchas) and keep PG + backend + frontend in one coherent range.
+- the Postgres **major** — pin the same one production runs (`references/snapshots.md`)
 - `app_server_dir` — repo root (single package) vs a subdir (monorepo)
 - `app_migrate` — how migrations run → **`references/migrations-and-seeds.md`**
 - single-service `dev` (frontend runs separately) vs fullstack `dev` (starts both,
   kills both) → use `references/bin/dev` or `references/bin/dev-fullstack`
-- whether the project seeds, and whether it has prod snapshots at all
+- the **seed posture** — synthetic SQL, snapshot-as-seed, or empty + per-suite
+  fixtures (`references/migrations-and-seeds.md`), and whether it has prod snapshots
+  at all (`references/snapshots.md`)
 
 ## Build order
 
 1. **Read the relevant references first** (below) — they encode hard-won bugs.
 2. Copy `references/bin/*` into the project's `bin/`, rename the prefix, fill the
-   constants in `_common.sh`. Pick a PG host port well outside 5432.
+   constants in `_common.sh`. **Claim a base port band** well outside 5432 and
+   distinct from your other projects (see gotchas — or derive it from a hash of the
+   repo name). Pin the **same Postgres major as production** so snapshots restore
+   cleanly (`references/snapshots.md`).
 3. Set `app_server_dir` and `app_migrate` for this project
    (`references/migrations-and-seeds.md`).
 4. Choose the `dev` variant (single-service vs `dev-fullstack`).
 5. Wire **test isolation** — the preload that points tests at `app_test`
-   (`references/test-isolation.md`). This is the highest-value step; do it even if
-   you skip everything else.
+   (`references/test-isolation.md`). Do this when (or before) the project grows a
+   DB-backed test suite: it's the step that stops tests wiping dev data. It's a clean
+   add later, but if you know tests are coming, scaffolding `bin/test` + the preload
+   up front means the *first* test is born-isolated.
 6. `chmod +x bin/*` (not `_common.sh`). Remove any `docker-compose.yml` that only
    templated local Postgres, and update `.env.example` + the project's agent docs
    (CLAUDE.md or equivalent) to point at `bin/`.
@@ -92,13 +106,27 @@ know which parts you copy verbatim and which you adapt.
 | `references/orchestrator-integration.md` | wiring Conductor/orchestrator setup/run/cleanup; the stdout/stderr contract |
 | `references/snapshots.md` | only if the project has a production DB to snapshot (skip for greenfield) |
 
+## Where this meets `ci-quality-gates`
+
+This skill and **`ci-quality-gates`** are complementary and meet at exactly one
+seam: the **`test` script**. `ci-quality-gates` owns the script contract
+(`lint`/`format`/`format:check`/`typecheck`/`test`) and the CI workflow that runs
+`bun run test` against an **ephemeral service-container Postgres** with an explicit
+`DATABASE_URL`. This skill owns what that same `test` script connects to **locally**:
+`bin/test` + the `bunfig.toml` preload force an isolated `app_test` DB, and the
+preload's `??=` is the handshake that lets CI's explicit `DATABASE_URL` win. Adopt
+both together for a DB-backed app — the CI skill defines the gate, this skill keeps
+it from clobbering dev data. (SquadQuest is the worked example: a `"test": "bun test"`
+script, `bin/test`, and a `bunfig.toml` preload that defers via `??=`.)
+
 ## Guardrails
 
 - Keep the scripts to **database + process lifecycle**. Rich demo/fixture data is
   the app's concern and churns fast — at most a thin idempotent seed hook
   (`migrations-and-seeds.md`). A bloated `bin/` stops being portable.
 - These are dev-only. **CI keeps its own explicit `DATABASE_URL`** against an
-  ephemeral DB; the test preload's `??=` defers to it. Verify CI stays green; you
-  shouldn't need to touch the CI workflow.
+  ephemeral DB (a GitHub Actions service-container Postgres, owned by
+  **`ci-quality-gates`**); the test preload's `??=` defers to it. Verify CI stays
+  green; you shouldn't need to touch the CI workflow.
 - Don't drop the canonical dev DB casually — `bin/cleanup` guards it behind
   `--force`; `bin/reset-db` is the intended "start the main DB over" path.

--- a/skills/agent-dev-workflow/references/gotchas.md
+++ b/skills/agent-dev-workflow/references/gotchas.md
@@ -30,6 +30,36 @@ If a worktree starts scanning at 4001, it skips a free 4000. Reuse the canonical
 port whenever it's actually free; let real listen-state — not worktree identity —
 decide collisions.
 
+## Two collision axes: worktrees *and* other projects
+
+The port logic above solves **intra-project** collisions — two worktrees of the
+*same* repo never grab the same port. It does nothing about **inter-project**
+collisions: run several Jarvus repos at once and they'd fight over ports if they
+shared a base. In practice they don't, because each repo claims a distinct **base
+port band** — e.g. one project in `25xx`, another in `35xx`, another's Postgres at
+`5532`. That base is a per-project constant *you* choose; the worktree logic only
+ranges within it.
+
+Two ways to choose it:
+
+- **Hand-pick** a distinct, uncommon high band per repo and keep PG + backend +
+  frontend coherent within it (e.g. PG `N530`, backend `N531–N599`, frontend
+  `N600–N699`). The traps: forgetting which bands are already taken, and splitting a
+  repo across unrelated bands (one real repo runs Postgres on `5532` but its server
+  on `4001–4099` — avoid that incoherence).
+- **Derive it from a hash of the repo name** — collision-resistant with no registry
+  to remember, the same trick the DB names use for worktree *paths*, applied at repo
+  granularity:
+
+  ```bash
+  # deterministic base in a high block (20000–59990), distinct per repo name
+  app_base_port() {
+    local n; n=$(basename "$(app_root)" | cksum | cut -d' ' -f1)
+    echo $(( 20000 + (n % 4000) * 10 ))
+  }
+  # then PG = base, backend range = base+1..base+49, frontend = base+50..base+99
+  ```
+
 ## postgres:18 changed the data directory layout
 
 On `postgres:18` the volume must mount at `/var/lib/postgresql`, **not**
@@ -37,6 +67,11 @@ On `postgres:18` the volume must mount at `/var/lib/postgresql`, **not**
 container's healthcheck never goes ready and `wait_for_postgres` times out after
 30s. If you pin `postgres:17-alpine` (the template default) use `…/data`; only
 change the mount if you deliberately move to 18.
+
+**Pin the same major production runs.** Whatever major your prod DB is (Cloud SQL,
+RDS, …), pin that in `_common.sh` so `strip_cloudsql`'d snapshots restore without
+version-mismatch surprises. Across Jarvus repos this currently drifts (16 / 17 / 18
+all in use) — match *your* prod, and mind the data-dir caveat above when it's 18.
 
 ## docker-compose can't do per-context isolation — remove it
 

--- a/skills/agent-dev-workflow/references/migrations-and-seeds.md
+++ b/skills/agent-dev-workflow/references/migrations-and-seeds.md
@@ -40,16 +40,30 @@ folder; they're two callers of one migration set, not two migration systems.
 Non-bun stacks: `alembic upgrade head` (Python), `rails db:migrate`,
 `migrate -path … up` (golang-migrate), etc. — same idea, swap the command.
 
-## Seeds (optional)
+## Seeds (optional) — three postures
 
-Some projects seed reference/demo data on a fresh DB; many don't. If yours does,
-uncomment the seed lines in `setup`/`reset-db` and make seeds **idempotent**
-(`INSERT … ON CONFLICT DO NOTHING`) so re-running is safe. Crucially, **don't seed
-when loading a snapshot** (the snapshot already has data) and **don't seed the
-test DB** (suites set up their own fixtures). A common shape is one or more
-`seed*.sql` files run on a fresh non-snapshot DB, plus an optional local
-`.scratch/extra-seed.sql` for personal data; other projects keep seeding out of
-`bin/` entirely (a one-off script run on demand). Pick whichever fits.
+How you populate a fresh dev DB is a project choice. Three postures seen across real
+repos:
+
+1. **Synthetic seeds** — hand-authored idempotent `seed*.sql`
+   (`INSERT … ON CONFLICT DO NOTHING`) run on a fresh non-snapshot DB, plus an
+   optional local `.scratch/extra-seed.sql` for personal data. Right when the curated
+   dataset *is* the product (e.g. a demo app).
+2. **Snapshot-as-seed** — no hand-written fixtures at all; `bin/load-snapshot`
+   (default → latest prod) *is* the seed. Right when real prod data exists; often the
+   only synthetic thing left is a dev auth token/secret applied at runtime, not at
+   setup. See **`references/snapshots.md`**. This is the guardrail's ideal — nothing
+   to maintain.
+3. **Empty + per-suite fixtures** — `setup` leaves the DB empty (just migrated) and
+   tests build their own fixtures per suite. Right when there's no meaningful shared
+   dev dataset (and prod data is PII you wouldn't pull to a laptop).
+
+Decision rule: **do you have meaningful prod data to pull?** Yes → snapshot-as-seed.
+No, but the dataset is the deliverable → synthetic. Neither → empty + fixtures.
+
+Whichever you pick: keep seeds **idempotent**, **don't seed when loading a snapshot**
+(it already has data), and **don't seed the test DB** (suites own their fixtures). To
+wire posture 1, uncomment the seed lines in `setup`/`reset-db`.
 
 ## A note on what NOT to put here
 

--- a/skills/agent-dev-workflow/references/snapshots.md
+++ b/skills/agent-dev-workflow/references/snapshots.md
@@ -5,6 +5,12 @@ opt-in** and only makes sense once there's a production database to snapshot. A
 greenfield project (no prod yet) should skip all of this — adding it early is
 dead weight.
 
+When a project *does* have real prod data, this is usually its **seeding
+strategy**: `bin/load-snapshot` (default → latest) replaces hand-written fixtures
+entirely (the "snapshot-as-seed" posture in **`migrations-and-seeds.md`**). One
+caveat for clean restores: pin the **same Postgres major as production** locally, so
+a `strip_cloudsql`'d dump doesn't hit version-mismatch surprises.
+
 Two scripts, both built on helpers already in `_common.sh`.
 
 ## bin/snapshot — export prod → object storage

--- a/skills/ci-quality-gates/SKILL.md
+++ b/skills/ci-quality-gates/SKILL.md
@@ -49,6 +49,14 @@ All four TS gates are invoked through a fixed **script contract** —
 across packages and only calls `bun run <name>`. Details + the naming caveat in
 [tool-standards.md](references/tool-standards.md).
 
+**DB-backed tests stay in this gate — they just need a database.** A `bun test` /
+`pytest` suite that hits Postgres is still fork-safe (no secrets), so it belongs
+here: give CI an **ephemeral service-container Postgres** and an explicit
+`DATABASE_URL`. Locally, that same `test` script gets an isolated DB from
+**`agent-dev-workflow`**'s `bin/test` + test preload, whose `??=` defers to CI's
+`DATABASE_URL`. (Integration tests that need *secrets* are the separate later gate
+in the scope table above.)
+
 ## The universal harness (don't reinvent it)
 
 Every job, every language, shares the same provisioning. Consolidate it into one


### PR DESCRIPTION
Folds findings from the three repos that use `agent-dev-workflow` — **SquadQuest**, **transit-lake**, and **jarvus-hq** — back into the skill. The invariant core is copied faithfully in all three; the value is in the *optional* pieces, where their choices reveal gaps in the guidance.

### Context: how the three compare
| | SquadQuest | transit-lake | jarvus-hq |
|---|---|---|---|
| Worktree isolation | ✓ | ✓ | ✓ |
| Test isolation | **✓ (reference impl, 18 tests)** | ✗ (no tests yet) | ✗ (no tests yet) |
| Snapshots | ✗ | ✓ GCS | ✓ GCS |
| Seed posture | empty + per-suite fixtures | synthetic SQL | snapshot-as-seed |
| PG major | 17 | 16 | 18 |
| Port band | PG 5532 / srv 4001–4099 | 35xx | 25xx |

Test isolation tracks "has a test suite" perfectly (1/1) — it's correctly deferred, not neglected.

### What's folded in
1. **`ci-quality-gates` seam.** The two skills meet at the `test` script. New "Where this meets `ci-quality-gates`" section + guardrail update spelling out the handshake (CI's ephemeral service-container Postgres + explicit `DATABASE_URL` ↔ the preload's `??=`). Reciprocal note added to `ci-quality-gates`: DB-backed tests stay in the gate but need an ephemeral Postgres; local isolation comes from `bin/test`. SquadQuest is cited as the worked example.
2. **Inter-project port collisions** (`gotchas.md` + knobs). Documents the *second* collision axis: worktree picking separates a project's own copies; the per-project **base port band** is what keeps *different projects* apart when several run at once. Hand-pick a distinct band, or derive it from a repo-name hash. Calls out SquadQuest's incoherent 5532/4001 split as the anti-pattern.
3. **Seeding as a 3-posture spectrum** (`migrations-and-seeds.md` ↔ `snapshots.md`): synthetic SQL / snapshot-as-seed / empty + per-suite fixtures, with a decision rule ("do you have meaningful prod data to pull?").
4. **Normalizations**: "pin the same Postgres major as production" (the three drift 16/17/18, which bites snapshot restores); keep the canonical `db` script name (transit-lake renamed it to `query`).
5. **Test-isolation build step** reworded from "highest-value, do it even if you skip everything else" to "do it when/before a DB-backed suite lands" — SquadQuest shows it's a clean later add, and born-isolated if scaffolded up front.

Docs-only; no template/script behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)