### PR TITLE
docs(ci-quality-gates): scope oxlint/oxfmt to source dirs, not `.`

### DIFF
--- a/skills/ci-quality-gates/references/tool-standards.md
+++ b/skills/ci-quality-gates/references/tool-standards.md
@@ -13,9 +13,9 @@ just calls `bun run <name>`:
 ```jsonc
 {
   "scripts": {
-    "lint":         "oxlint <paths>",          // e.g. "oxlint ." or "oxlint index.ts src"
-    "format":       "oxfmt <paths>",           // writes
-    "format:check": "oxfmt --check <paths>",   // CI uses this
+    "lint":         "oxlint <src dirs>",       // e.g. "oxlint src bin test" — scope, don't use "."
+    "format":       "oxfmt <src dirs>",        // writes
+    "format:check": "oxfmt --check <src dirs>",// CI uses this
     "typecheck":    "tsc --noEmit"             // or "tsc -b" for project-references
   }
 }
@@ -34,6 +34,14 @@ bun add -d oxlint oxfmt
 
 ## TypeScript: oxlint + oxfmt + tsc
 
+- **Scope to your source dirs, not `.`.** Pass the actual TypeScript directories
+  (`oxlint src bin test`), not a bare `.`. Two traps a bare `.` walks into: it
+  lints **vendored content you don't own** — committed skill bundles under
+  `.agents/`/`.claude/`, generated `dist/` — surfacing errors from other people's
+  code; and **oxfmt formats Markdown by default**, so `oxfmt .` will reformat your
+  `specs/**` and `*.md` docs. A bare `.` is only safe in a clean, isolated package
+  whose root holds nothing but its own source (e.g. a `ui/` subpackage). When in
+  doubt, list the dirs.
 - **oxlint** — fast Rust linter. Config is `.oxlintrc.json`.
   - **Single-package repo:** use `templates/oxlintrc.base.json` directly as the
     package's `.oxlintrc.json`.


### PR DESCRIPTION
## What

Scopes the oxlint/oxfmt guidance in `ci-quality-gates` to **source directories** instead of a bare `.`, and adds a short note explaining why.

## Why

A dry-run adopting the skill on a single-package Bun CLI (`otter-axi`) surfaced two traps a fresh agent hits with `oxlint .` / `oxfmt .`:

- it **lints vendored content the repo doesn't own** — committed skill bundles under `.agents/` / `.claude/`, generated `dist/` — surfacing errors from other people's code;
- **oxfmt formats Markdown by default**, so `oxfmt .` reformats `specs/**` and `*.md` docs.

The agent worked around it correctly on its own (scoped to `src bin test`), but the skill shouldn't make it. Now the script contract shows explicit source dirs, and a note reserves `.` for clean isolated packages (e.g. a `ui/` subpackage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QHVPQXzEiaPAupLgDa7D5n