### PR TITLE
docs(ci-quality-gates): asdf-plugin caveat + project-references typecheck

### DIFF
--- a/skills/ci-quality-gates/references/provisioning.md
+++ b/skills/ci-quality-gates/references/provisioning.md
@@ -17,7 +17,32 @@ python 3.12.13
 opentofu 1.11.5
 ```
 
-## The composite action (use this, don't copy-paste the block)
+## First: does the asdf composite even fit this repo?
+
+The composite below installs **every** tool in `.tool-versions` via
+`asdf-vm/actions/install`, which runs `asdf plugin add <tool>` for each. That only
+works if **every pinned tool has a plugin in the asdf registry.** Repos often pin
+tools that don't — `duckdb`, say, has no registry plugin, so `asdf plugin add
+duckdb` fails and takes down *every job that uses the composite* (a real failure
+seen adopting this on a DuckDB monorepo: lint + tf all red, only the non-asdf
+Docker job survived). It works locally only because the dev already has the tool.
+
+So choose provisioning by what the repo pins:
+
+- **All pinned tools have asdf plugins** → use the composite (next section). One
+  provisioning path, fully cached.
+- **`.tool-versions` includes a tool with no asdf plugin** (duckdb, niche tools),
+  **or** a job only needs one tool → **skip the composite and provision just what
+  each gate needs** with targeted setup actions. This is also faster (no installing
+  python/uv/duckdb for a lint job):
+  - TS lint/test → `oven-sh/setup-bun@v2` with `bun-version-file: .tool-versions`
+  - IaC → `opentofu/setup-opentofu@v1` with `tofu_version` (+ `tofu_wrapper: false`)
+  - Python → `astral-sh/setup-uv@v7` (or asdf if uv+python both have plugins)
+
+  Targeted actions still read versions from `.tool-versions` where they can, so
+  it stays the single source of truth.
+
+## The composite action (when every pinned tool has a plugin)
 
 The provisioning steps repeat in every job. continuous-gtfs currently inlines
 them ~6 times across `lint.yml` / `test.yml` / `ui-checks.yml`; that's the proven

--- a/skills/ci-quality-gates/references/templates/github-actions/lint.yml
+++ b/skills/ci-quality-gates/references/templates/github-actions/lint.yml
@@ -38,6 +38,12 @@ jobs:
   # --- TypeScript (oxc + tsc). Delete this job if the repo has no TS. --------
   # Single-package repo: drop the matrix, set working-directory to the package,
   # and inline the three steps. The matrix is for monorepos with several packages.
+  #
+  # PROJECT-REFERENCES MONOREPO? If packages reference each other (root tsconfig
+  # with `references`), do NOT type-check per package here — a per-package
+  # `tsc --noEmit` doesn't BUILD referenced deps, so it fails in a clean checkout
+  # when a dep's declarations don't exist yet. Drop the per-package Type check
+  # step below and add the separate root `typecheck` job at the bottom instead.
   ts-lint:
     name: oxc (${{ matrix.package }})
     runs-on: ubuntu-latest
@@ -64,3 +70,18 @@ jobs:
       - name: Type check
         if: ${{ matrix.typecheck }}
         run: bun run typecheck
+
+  # --- Root type-check (PROJECT-REFERENCES MONOREPO ONLY) -------------------
+  # Use this INSTEAD of the per-package Type check step above when packages
+  # reference each other. `tsc -b` (build mode) builds referenced projects in
+  # dependency order, so cross-package types resolve in a clean checkout. The
+  # root `typecheck` script should be `tsc -b`. Delete this job if not a
+  # project-references monorepo.
+  # typecheck:
+  #   name: Type check (tsc -b)
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v6
+  #     - uses: ./.github/actions/setup-asdf   # or oven-sh/setup-bun@v2
+  #     - run: bun install --frozen-lockfile
+  #     - run: bun run typecheck                # root script = tsc -b

--- a/skills/ci-quality-gates/references/tool-standards.md
+++ b/skills/ci-quality-gates/references/tool-standards.md
@@ -73,6 +73,15 @@ bun add -d oxlint oxfmt
 - **tsc** — type-check only, `--noEmit` (Bun runs the source; tsc never builds).
   `strict: true` belongs in `tsconfig.json` — type-check *is* a gate, it catches
   a whole class of bugs no linter does.
+  - **Project-references monorepo:** if the root `tsconfig.json` has a
+    `references` array (packages depending on packages), type-check at the **root
+    with `tsc -b`** (build mode), as one job — `tsc -b` builds referenced projects
+    in dependency order. A per-package `tsc --noEmit` does *not* build its deps, so
+    it fails in a clean CI checkout when a referenced package's declarations don't
+    exist yet (it passes locally only because a prior build left them around). So
+    the root `typecheck` script is `tsc -b`, and the lint matrix runs per-package
+    **lint + format only** (neither needs type info). See the root `typecheck` job
+    in `templates/github-actions/lint.yml`.
 
 **Philosophy: correctness-as-error, style-as-warn.** The base config sets the
 `correctness` category to `error` and little else — no opinionated style churn on


### PR DESCRIPTION
## What

Two more refinements to `ci-quality-gates`, both from CI failures hit adopting it on the **transit-lake** DuckDB monorepo (transit-lake#51) — each passed locally but failed in Actions:

1. **asdf composite ≠ universal.** It runs `asdf plugin add` for *every* tool in `.tool-versions`; tools without a registry plugin (e.g. `duckdb`) make it exit 1 and fail every job using it. Added a "does the composite fit this repo?" section up front: use it only when all pinned tools have plugins; otherwise provision per-gate with targeted actions (`setup-bun` / `setup-opentofu` / `setup-uv`) — which is faster anyway.

2. **Project-references monorepo type-checking.** Per-package `tsc --noEmit` doesn't *build* referenced deps, so it fails in a clean checkout when a dep's declarations don't exist. Type-check at the root with `tsc -b` (build mode). Documented in `tool-standards.md`, plus a warning + ready-to-use root `typecheck` job added to the `lint.yml` template.

Pure docs/template guidance. This is the third hardening pass — each real adoption (otter → scoping #22; transit-lake → #23, now this) makes the skill correct for the next repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QHVPQXzEiaPAupLgDa7D5n