### PR TITLE
docs(ci-quality-gates): rationalized enforcement philosophy (CI-only, workflow-by-toolchain)

### DIFF
--- a/skills/ci-quality-gates/SKILL.md
+++ b/skills/ci-quality-gates/SKILL.md
@@ -29,12 +29,48 @@ re-deciding — or skipping it.
 One-sentence charter: **how a repo gates a PR before it merges.** If credentials
 or a release tag are involved, it's a different skill.
 
+## Enforcement philosophy
+
+Three decisions shape how everything below is wired:
+
+**1. CI is the only gate — no pre-commit.** The gate lives in CI and nowhere else.
+Pre-commit hooks are per-developer (must be installed, drift between machines, and
+are one `--no-verify` from being skipped), add commit-time friction, and only ever
+*duplicate* what CI already enforces authoritatively. So **don't ship a
+`.pre-commit-config.yaml`.** Run each linter **directly** in CI — `oxlint`,
+`oxfmt --check`, `ruff check`, `sqlfluff lint --format github-annotation-native` —
+which keeps inline PR annotations without the framework. Local fast feedback comes
+from the **editor** (oxc-vscode, ruff, a sqlfluff LSP) and from running the same
+`bun run <gate>` / tool commands by hand — never a git hook.
+
+**2. Organize workflows by gate; co-locate by toolchain.** The default lanes are
+`lint` and `test`, each a workflow whose jobs fan out per package/language. But when
+a domain brings a **distinct toolchain**, give it its **own workflow whose jobs are
+named by gate** instead of forcing that toolchain into the generic lint/test
+workflows. Terraform (`tf-validate.yml`: `fmt` + `validate`) is the first instance;
+**dbt** is the second — its `sqlfluff` linter compiles models *through dbt*, so it
+needs the same `uv` + `dbt deps` + profile setup as `dbt parse`/unit-tests.
+Co-locating those in one `dbt.yml` (jobs `lint` / `parse` / `unit-test`) stands the
+toolchain up once and keeps the gate semantics legible; splitting them across
+`lint.yml` and `test.yml` would provision dbt twice. **Rule of thumb: one workflow
+per toolchain, jobs named by gate.** Fold into the shared `lint.yml`/`test.yml` only
+when a check rides the *same* toolchain those already set up.
+
+**3. Stack skills own their tools; this skill owns the harness.** Each
+`jarvus-{tech}` stack skill defines its tech's linter/formatter/test choices,
+configs, and `package.json`/script contract, and carries a short "CI & Code Quality"
+section pointing here. This skill owns provisioning, the gate taxonomy, the
+path-filter / lockfile-frozen / credential-free rules, and the workflow templates. A
+stack skill that introduces a distinct toolchain ships its **domain workflow** (its
+lane of this contract) — e.g. **`jarvus-dbt`** ships `dbt.yml`. A new stack plugs
+into these rules rather than reinventing CI.
+
 ## The two reference deep-dives
 
 | File | Read when |
 |---|---|
 | [provisioning.md](references/provisioning.md) | the CI harness — asdf + cache composite, lockfile-frozen installs, path filters, credential-free principle, private-dep git rewrite |
-| [tool-standards.md](references/tool-standards.md) | the linters/formatters — the TS script contract, oxc + ruff configs, the `typecheck` naming convention, pre-commit's optional role, the one-time adoption migration |
+| [tool-standards.md](references/tool-standards.md) | the linters/formatters — the TS script contract, oxc + ruff configs, the `typecheck` naming convention, the editor-feedback loop (no pre-commit), the one-time adoption migration |
 
 ## The gate set
 
@@ -128,9 +164,11 @@ Plus three rules that make CI reproducible and cheap (full rationale in
   Vite scaffold ships a default eslint; remove it when adopting oxc.
 - **Type-check is a gate, not a nicety.** `tsc --noEmit` / strict mode catches
   bugs no linter does — keep it required.
-- **Pre-commit is optional, not the gate.** CI is the source of truth; the IDE is
-  local feedback. Only reach for a `.pre-commit-config.yaml` on multi-linter
-  Python repos (ruff + sqlfluff + markdown + …). See
+- **No pre-commit framework.** CI is the only gate; run linters directly in CI (they
+  emit PR annotations natively). Local feedback is the editor + running the gate
+  commands by hand. Don't add a `.pre-commit-config.yaml` — even on multi-linter
+  repos (ruff + sqlfluff + markdown), run each tool directly in CI or in the domain's
+  workflow. See the enforcement philosophy above and
   [tool-standards.md](references/tool-standards.md).
 - **Stay before the merge line.** Release, build, publish, deploy, and
   credentialed plans belong to other skills. If you're editing

--- a/skills/ci-quality-gates/references/provisioning.md
+++ b/skills/ci-quality-gates/references/provisioning.md
@@ -111,8 +111,9 @@ fork-safe-ish; just be aware forks won't have the secret.
 
 ## What this deliberately is NOT
 
-- **No pre-commit framework as the gate.** CI is the gate; the IDE is the fast
-  local feedback loop (see `tool-standards.md`). Pre-commit is an optional extra
-  tier, not the source of truth — the flagship and newest repos skip it.
+- **No pre-commit framework — at all.** CI is the gate; the editor is the fast
+  local feedback loop (see `tool-standards.md`). Linters run **directly** in CI and
+  emit their own PR annotations; we don't wrap them in `pre-commit/action`, even on
+  multi-linter (SQL/Python/markdown) repos.
 - **No build/publish/deploy here.** Those belong to per-stack build docs and the
   deploy/sysadmin skills. Release PR automation belongs to `release-flow`.

--- a/skills/ci-quality-gates/references/tool-standards.md
+++ b/skills/ci-quality-gates/references/tool-standards.md
@@ -113,20 +113,22 @@ root module. Format + config-validity only — never `tofu plan` in this gate
 A docs site (mkdocs) gets a build gate: `mkdocs build --strict` so a broken link
 or missing nav entry fails the PR. Trigger on `docs/**` + `mkdocs.yml`.
 
-## IDE recommendation, not pre-commit
+## Local feedback: the editor, never a git hook
 
 Local fast feedback comes from the editor, not git hooks. Commit
 `templates/vscode-extensions.json` as `.vscode/extensions.json` to recommend the
-**oxc.oxc-vscode** extension (lint + format-on-save matching CI). For Python,
-ruff's editor integration plays the same role.
+**oxc.oxc-vscode** extension (lint + format-on-save matching CI). Ruff's editor
+integration and a sqlfluff LSP play the same role for Python and SQL.
 
-**Pre-commit is an optional extra tier, not the gate.** The flagship
-(continuous-gtfs) and the newest repos deliberately run checks in CI + IDE and
-*skip* a pre-commit framework. Where it earns its keep is multi-linter Python
-repos that also lint SQL/markdown/notebooks (e.g. ruff + sqlfluff + markdownlint +
-nbstripout) — there a `.pre-commit-config.yaml` driven by `pre-commit/action` in
-CI consolidates many hooks. Don't add it to a plain TS or single-linter Python
-repo; it's friction without payoff there.
+**No pre-commit framework — including on multi-linter repos.** CI is the only gate
+(see the enforcement philosophy in `SKILL.md`). Even a repo that lints SQL + Python +
+markdown + notebooks runs each tool **directly** in CI (or in its domain workflow),
+not behind `pre-commit/action`: `sqlfluff lint --format github-annotation-native`,
+`ruff check`, and `oxlint` all emit PR annotations on their own. The framework only
+adds per-developer install friction and a `--no-verify` bypass without buying
+anything CI doesn't already enforce. (This is a deliberate move *away* from the
+pre-commit-driven CI some older repos use, e.g. wmata's `pre_commit.yaml` — new and
+migrated repos run the tools directly.)
 
 ## Adopting on an existing repo: the one-time migration
 


### PR DESCRIPTION
Codifies the enforcement philosophy in `ci-quality-gates` so the stack skills (and the new `jarvus-dbt`) plug into one coherent model. New "Enforcement philosophy" section + aligned guardrails/references.

## The three decisions

1. **CI is the only gate — no pre-commit.** Drops the prior "pre-commit is optional / earns its keep on multi-linter repos" stance entirely. Pre-commit is per-developer (install drift, `--no-verify` bypass) and only duplicates CI. We **don't ship a `.pre-commit-config.yaml`**; we run each linter **directly** in CI — `oxlint`, `oxfmt --check`, `ruff check`, `sqlfluff lint --format github-annotation-native` (they all emit PR annotations natively). Local feedback = editor (oxc-vscode, ruff, sqlfluff LSP) + running the gate commands by hand. Explicit move away from pre-commit-driven CI (e.g. wmata's `pre_commit.yaml`).

2. **Organize workflows by gate; co-locate by toolchain.** Default lanes are `lint` and `test`. When a domain brings a **distinct toolchain**, it gets its **own workflow with gate-named jobs** instead of being forced into the generic lint/test workflows. `tf-validate.yml` is the first instance; **dbt** is the second — `sqlfluff` compiles *through dbt*, so it shares `uv`+`dbt deps`+profile setup with `dbt parse`/unit-tests; co-locate them in `dbt.yml` (jobs `lint`/`parse`/`unit-test`) rather than provisioning dbt twice. **One workflow per toolchain, jobs named by gate.**

3. **Stack skills own their tools; this skill owns the harness.** Each `jarvus-{tech}` skill defines its tech's linters/configs/scripts + a "CI & Code Quality" section pointing here; this skill owns provisioning, the gate taxonomy, and the path-filter/lockfile-frozen/credential-free rules. A stack skill with a distinct toolchain ships its domain workflow (e.g. `jarvus-dbt` → `dbt.yml`).

Updates: the guardrail (pre-commit → no pre-commit), `tool-standards.md` ("local feedback: the editor, never a git hook"), and `provisioning.md` ("no pre-commit framework — at all").

## Follow-on
`jarvus-dbt` (PR #28) will be updated to match — run `sqlfluff` directly in CI and drop its pre-commit template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)