### PR TITLE
docs(jarvus-dbt): address dbt-lead review (#28)

### DIFF
--- a/skills/jarvus-dbt/README.md
+++ b/skills/jarvus-dbt/README.md
@@ -20,9 +20,10 @@ mechanics.
 **Recommended scope: per-project**, alongside the dbt-labs skills:
 
 ```bash
-npx skills add JarvusInnovations/agent-skills --skill jarvus-dbt
-# plus the first-party mechanics skills it references:
+# the first-party dbt mechanics skills this builds on (install first):
 npx skills add dbt-labs/dbt-agent-skills
+# then the Jarvus house layer:
+npx skills add JarvusInnovations/agent-skills --skill jarvus-dbt
 ```
 
 See `SKILL.md` for the conventions and `references/` for the modeling rules, testing patterns,

--- a/skills/jarvus-dbt/references/conventions.md
+++ b/skills/jarvus-dbt/references/conventions.md
@@ -27,12 +27,13 @@ Never assume a default. Choose per model and record why:
 - **incremental** (incl. `microbatch`) — large append-mostly facts; pick the grain and
   `event_time` carefully.
 
-Pick the **grain** before the materialization, and don't multiply rows you don't need.
-*Case in point:* a schedule fact built as one row per `(service_date, trip_id)` exploded a
-TIDES dataset to ~229M rows; rebuilt as **date-free, feed-scoped facts** (one row per
-`(_feed_digest, trip_id)`) plus a narrow calendar map, it dropped to ~53M — consumers join
-the calendar and compute timestamps inline. Prefer a date-free fact + calendar map over
-materializing a schedule across every service date.
+Pick the **grain** before the materialization, and let **observed performance when the model
+is consumed** drive the choice — not table size on its own. A big table isn't a problem until
+something querying it is slow; a "small" model can still warrant a table if it's on a hot path.
+*Example:* a schedule fact keyed per `(service_date, trip_id)` was fine to build but slow once
+consumed; re-grained to date-free, feed-scoped facts (one row per `(_feed_digest, trip_id)`)
+plus a narrow calendar map that consumers join, it performed. The transferable lesson is the
+**method** — choose grain, then measure consumption — not a blanket "avoid date-scoped facts."
 
 ## No inner joins
 
@@ -69,6 +70,29 @@ scheduled_trips as (
 Readability + dependency tracing: a reader sees every input in one place, and the logic CTEs
 reference clearly-named relations rather than inline `ref()` calls.
 
+## End every model with a named, fully-enumerated SELECT
+
+A model's final statement is a CTE **named the same as the model**, with **every output column
+enumerated** (no `select *` from upstream), followed by `select * from <model_name>`:
+
+```sql
+dim_stops as (
+    select
+        stop_id,
+        stop_name,
+        stop_lat,
+        stop_lon,
+    from ...
+)
+
+select * from dim_stops
+```
+
+Three payoffs: the **model's name appears inside its own file** (so a VS Code search for the
+model name lands in its code), the **column list is explicit** so it's easy to audit against the
+model's docs, and **PR diffs highlight what's actually changing on the output** rather than
+burying it in intermediate logic.
+
 ## Semantic table aliases
 
 **Never letter abbreviations** (`vp`, `st`, `sv`, `tp`, `dsf`, `t`, `s`). Derive a short noun
@@ -94,7 +118,9 @@ human call — see [linting-and-ci.md](linting-and-ci.md).
 
 ## Timeless comments
 
-Comments describe what the code **persistently is**, never what changed. Don't write
+(General code-comment hygiene, not dbt-specific — kept here because AI-generated models
+frequently narrate their own edits.) Comments describe what the code **persistently is**, never
+what changed. Don't write
 "renamed from X", "replaced the in-flight Z", "now uses…". Write what the thing is and why it
 exists. Change narration belongs in the commit message, not the source.
 

--- a/skills/jarvus-dbt/references/deployment.md
+++ b/skills/jarvus-dbt/references/deployment.md
@@ -1,4 +1,4 @@
-# Deployment patterns (DEFERRED — second pass)
+# Deployment patterns — TODO (deferred second pass, not yet written)
 
 > **Not written yet.** The first pass of `jarvus-dbt` covers model *quality* (conventions,
 > testing, lint/CI). The run/orchestration/publish side is deliberately deferred so it can be
@@ -14,6 +14,9 @@ even though they're not authorities on model quality):
   for asset lineage (jarvus-data-pipeline pattern).
 - **External materialization & handoff** — DuckDB → object storage (GCS) external models and
   cross-container handoff (co-air-quality-udda pattern); `on-run-start` registration macros.
+  (Note: this one straddles deployment *and* data-access / client-facing performance — it lands
+  here mainly because it doesn't merit its own skill and isn't a modeling "convention"; revisit
+  the placement when this section is written.)
 - **Warehouse auth in CI/prod** — BigQuery service account / Workload Identity vs the
   credential-free DuckDB path; CI targets and keyfile handling.
 - **Cross-platform moves** — DuckDB ↔ BigQuery; reference dbt-labs' `dbt-migration` skills.

--- a/skills/jarvus-dbt/references/linting-and-ci.md
+++ b/skills/jarvus-dbt/references/linting-and-ci.md
@@ -5,40 +5,19 @@ Copy-paste config is in [templates/](templates/); this explains the choices.
 
 ## sqlfluff config
 
-Config lives in `pyproject.toml` (co-located with the project's other tooling). The house
-baseline — DuckDB shown; swap `dialect`/adapter deps for BigQuery:
+The full config (with `# ADAPT` markers) is the copy-paste template
+[templates/sqlfluff.pyproject.toml](templates/sqlfluff.pyproject.toml) — paste it into the
+project's `pyproject.toml`. The choices that matter:
 
-```toml
-[tool.sqlfluff.core]
-dialect = "duckdb"          # or "bigquery"
-templater = "dbt"
-max_line_length = 120
-layout_config_style = "vertical"   # keywords on new lines
-
-[tool.sqlfluff.templater.dbt]
-project_dir = "warehouse"
-profiles_dir = "warehouse"
-target = "local"
-
-[tool.sqlfluff.layout.type.comma]
-line_position = "trailing"
-
-# lowercase everything
-[tool.sqlfluff.rules.capitalisation.keywords]
-capitalisation_policy = "lower"
-[tool.sqlfluff.rules.capitalisation.identifiers]
-extended_capitalisation_policy = "lower"
-# (functions / types / literals likewise)
-
-# house rules that ARE machine-enforceable with stock sqlfluff:
-[tool.sqlfluff.rules.aliasing.forbid]
-force_enable = true                 # no unnecessary table aliases
-[tool.sqlfluff.rules.references.qualification]   # require qualified columns
-```
+- `templater = "dbt"`, `dialect = "duckdb"` (or `"bigquery"`), `max_line_length = 120`,
+  `vertical` layout, trailing commas.
+- **lowercase** keywords / identifiers / functions / types / literals.
+- house rules stock sqlfluff *can* enforce: **`aliasing.forbid`** (no unnecessary aliases) and
+  **`references.qualification`** (qualified columns).
 
 `templater = "dbt"` means sqlfluff compiles models through dbt, so it needs the dbt adapter
-available and a `profiles_dir` (in CI we write a throwaway DuckDB profile — see the gate
-below). Pin the sqlfluff and adapter versions in the CI lint job install (the `uv` linters group).
+available and a `profiles_dir` (in CI we write a throwaway DuckDB profile — see the gate below).
+Pin the sqlfluff and adapter versions in the CI lint job install (the `uv` linters group).
 
 ### Which conventions stock sqlfluff covers — and which it doesn't
 

--- a/skills/jarvus-dbt/references/templates/github-actions/dbt.yml
+++ b/skills/jarvus-dbt/references/templates/github-actions/dbt.yml
@@ -1,28 +1,24 @@
 name: dbt
 
-# Credential-free dbt gate for the DuckDB stack: SQL lint + per-tenant parse + unit tests.
+# Credential-free dbt gate for the DuckDB stack: SQL lint + per-project parse + unit tests.
 # Reads only public data, so it needs no warehouse secret and runs on fork PRs. Mirror your
 # repo's existing provisioning (this uses uv directly, like the dbt projects do).
-# ADAPT: the path filters, the `tenants` matrix, and the working directories.
+#
+# Everything in ALL-CAPS / <angle-brackets> below is a PLACEHOLDER — replace it. The path
+# filters, the project matrix, and the working directories are all repo-specific. (For a real,
+# working instance see transit-lake's .github/workflows/dbt.yml.)
 on:
   pull_request:
     branches: [main]
-    paths:
-      - 'packages/dbt-*/**'        # ADAPT
-      - 'tenants/**'               # ADAPT
+    paths: &dbt_paths
+      - '<DBT_PROJECT_GLOB>/**'        # ADAPT: e.g. packages/dbt-*/**, warehouse/**, tenants/**
       - 'pyproject.toml'
       - 'uv.lock'
       - '.tool-versions'
       - '.github/workflows/dbt.yml'
   push:
     branches: [main]
-    paths:
-      - 'packages/dbt-*/**'
-      - 'tenants/**'
-      - 'pyproject.toml'
-      - 'uv.lock'
-      - '.tool-versions'
-      - '.github/workflows/dbt.yml'
+    paths: *dbt_paths
 
 permissions:
   contents: read
@@ -39,23 +35,26 @@ jobs:
       - name: Set up dbt (sqlfluff uses the dbt templater)
         run: |
           # ADAPT: write a throwaway DuckDB profile + install deps so sqlfluff can compile models
-          uv run dbt deps        # ADAPT --project-dir as needed
+          uv run dbt deps        # ADAPT: --project-dir / --profiles-dir as needed
       - name: sqlfluff lint (inline annotations, run directly — no pre-commit)
         run: |
-          uv run sqlfluff lint packages tenants \
+          uv run sqlfluff lint <MODEL_DIRS> \
             --config pyproject.toml \
-            --format github-annotation-native --annotation-level failure   # ADAPT paths
+            --format github-annotation-native --annotation-level failure   # ADAPT: <MODEL_DIRS>
 
   parse:
-    name: dbt parse (${{ matrix.tenant }})
+    name: dbt parse (${{ matrix.project }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        tenant: [septa, mta, rfta]   # ADAPT: every tenant/project must parse
+        # ADAPT: one entry per dbt project dir — EVERY tenant/project must parse.
+        project:
+          - <path/to/projectA>
+          - <path/to/projectB>
     defaults:
       run:
-        working-directory: tenants/${{ matrix.tenant }}/${{ matrix.tenant }}   # ADAPT
+        working-directory: ${{ matrix.project }}
     steps:
       - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v7
@@ -63,9 +62,11 @@ jobs:
           enable-cache: true
       - name: dbt deps + parse
         run: |
-          uv run --project ../../.. dbt deps --profiles-dir .
-          uv run --project ../../.. dbt parse --profiles-dir .
+          # ADAPT: --project points at the uv project that has dbt installed.
+          uv run --project "$GITHUB_WORKSPACE/<UV_PROJECT_DIR>" dbt deps --profiles-dir .
+          uv run --project "$GITHUB_WORKSPACE/<UV_PROJECT_DIR>" dbt parse --profiles-dir .
 
+  # OPTIONAL — delete if there are no dbt unit tests yet. Fixtures only, no warehouse.
   unit-tests:
     name: dbt unit tests
     runs-on: ubuntu-latest

--- a/skills/jarvus-dbt/references/testing.md
+++ b/skills/jarvus-dbt/references/testing.md
@@ -47,8 +47,11 @@ models:
 
 ## 2. Quality-model pattern (record-level validation in the DAG)
 
-For facts where some records are invalid but you don't want to silently drop them, split
-validation into a model so the result is materialized, queryable, and monitorable:
+A pattern to **consider** — not a blanket requirement. It carries real overhead (an extra
+model per fact), so reach for it where record-level validity genuinely matters, and **ask the
+developer** before adding it rather than applying it everywhere by default. Where it fits: facts
+where some records are invalid but you don't want to silently drop them — split validation into
+a model so the result is materialized, queryable, and monitorable:
 
 ```
 int_<thing>  →  fct_<thing>_quality  →  fct_<thing>


### PR DESCRIPTION
Incorporates @lauriemerrell's review of #28 (which had already merged). Point-by-point:

| Her comment | Change |
|---|---|
| New convention (top-level): models should end with a named CTE = model name, all columns enumerated, then `select * from <model>` | **Added** to `conventions.md` ("End every model with a named, fully-enumerated SELECT") — searchability, column/doc audit, clearer PR diffs |
| Materialization example too specific / may be walked back; size wasn't the problem, consumption performance was | Reframed to **evaluate materialization on observed consumption performance**; softened the example to "method, not blanket rule" |
| Timeless comments "isn't really dbt-specific" | Noted it's **general code hygiene**, kept because AI models narrate edits |
| Quality-model pattern shouldn't be blanket (overhead) | Downgraded to **"consider / ask the developer"** |
| "Why replicate this entire [sqlfluff] file inline?" | **DRY'd** — show the key choices, point to the template |
| Hardcoded values in the template (matrix); ADAPT flags | Template **genericized** — placeholders + `# ADAPT` for paths, project matrix, uv project dir |
| deployment.md should signal it's a TODO | H1 now **"TODO (deferred second pass, not yet written)"**; added her note that external-materialization straddles deployment vs data-access |
| Nit: list dbt-labs skills first (dependency) | README install **reordered** — dbt-labs first |

After merge I'll `npx skills update` in transit-lake to pull the refreshed skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)