### PR TITLE
docs(jarvus-fastify): rewrite auth reference around deny-by-default; add proxy-backend + Bun gotchas

### DIFF
--- a/skills/jarvus-fastify/SKILL.md
+++ b/skills/jarvus-fastify/SKILL.md
@@ -39,10 +39,10 @@ repo also ships an npm-distributed CLI that needs the Node toolchain.
 ## Reference Files
 
 | File | When to Use |
-|------|-------------|
+| ------ | ------------- |
 | [setup-guide.md](references/setup-guide.md) | Starting a new backend project from scratch |
 | [patterns.md](references/patterns.md) | Implementing routes, services, schema validation |
-| [authentication.md](references/authentication.md) | Adding JWT auth, authorization, protected routes |
+| [authentication.md](references/authentication.md) | Auth: deny-by-default gateway, sessions, tokens, OIDC, local dev mode |
 | [api-design.md](references/api-design.md) | Swagger/OpenAPI integration, response format, errors |
 | [mcp-integration.md](references/mcp-integration.md) | Integrating MCP server for AI agent access |
 | [gotchas.md](references/gotchas.md) | Debugging issues, common mistakes and fixes |
@@ -103,10 +103,19 @@ const apiKey = fastify.config.API_KEY
 const port = process.env.PORT  // Don't do this
 ```
 
+`@fastify/env`'s JSON Schema covers per-variable shape validation. When config needs
+cross-field contracts ("exactly one of these two modes"), environment-detection guards,
+or strict tri-state booleans, hand-rolled fail-fast validation at boot is the right tool
+— see setup-guide.md "When JSON Schema isn't enough".
+
 ### Response Format
 
+Pick one convention per API and stick to it. The envelope below is one option; structured
+domain-specific bodies (e.g. `{error: "forbidden", required, environment, your_role}`) are
+equally valid and often spec-mandated — see [api-design.md](references/api-design.md).
+
 ```typescript
-// Standard response structure
+// The envelope option
 {
   success: boolean
   data?: T

--- a/skills/jarvus-fastify/references/api-design.md
+++ b/skills/jarvus-fastify/references/api-design.md
@@ -4,7 +4,25 @@ Patterns for designing consistent, well-documented APIs with Fastify.
 
 ## Response Format
 
-Use a consistent response structure across all endpoints:
+Pick **one** response convention and apply it consistently across the API. The
+`{success, data, error}` envelope below is one solid option — not a requirement.
+Structured domain-specific bodies are equally valid and often spec-mandated: returning
+the resource directly on success, and on error a body whose `error` field is a
+**machine-branchable discriminator** with domain fields alongside, e.g.
+
+```typescript
+// 403 - the client can branch on error and render a specific message
+{ error: 'forbidden', required: 'operator', environment: 'production', your_role: 'viewer' }
+
+// 409 - a domain conflict carrying its own contract
+{ error: 'env_promote_only', environment: 'production', promotes_from: 'staging' }
+```
+
+If a spec defines error contracts like these, follow the spec — don't wrap them in an
+envelope. What matters is consistency and that error bodies are branchable, not the
+particular wrapper.
+
+### The Envelope Option
 
 ```typescript
 // Success response
@@ -123,7 +141,7 @@ fastify.post('/users', async (request, reply) => {
 ### HTTP Status Codes
 
 | Code | Usage |
-|------|-------|
+| ------ | ------- |
 | 200 | Successful GET, PUT, PATCH |
 | 201 | Successful POST (resource created) |
 | 204 | Successful DELETE (no content) |

--- a/skills/jarvus-fastify/references/authentication.md
+++ b/skills/jarvus-fastify/references/authentication.md
@@ -1,377 +1,446 @@
-# Authentication Patterns
+# Authentication & Authorization
 
-Patterns for implementing JWT authentication and authorization in Fastify backends.
+Patterns for authenticating and authorizing requests in Fastify backends. The model:
+**deny by default over the whole surface**, sessions in httpOnly cookies backed by a
+revocable token store, and authorization resolved from live state — never from token
+claims.
+
+## The Model: Deny by Default
+
+The single most important decision is the default. There are two ways to wire auth:
+
+- **Allow by default** — a global hook does optional auth; routes opt IN to protection
+  with a per-route `preHandler`. **Don't do this.**
+- **Deny by default** — a global hook requires an authenticated principal for every
+  request the router matches; anonymity is an explicit, enumerated allowlist. Routes
+  declare what they require; an undeclared route fails closed.
+
+Why allow-by-default fails: every new route is born unprotected. Protection depends on
+each author remembering to attach the right `preHandler`, forever — and the uncovered
+fork is exactly where holes hide. A security review of a production Fastify service
+built on the opt-in model found its environment-admin CRUD routes reachable completely
+unauthenticated: nobody had opted them in. Deny-by-default makes that class of bug
+structurally impossible — a new route is authenticated the moment it exists, and making
+one anonymous is a deliberate, reviewed addition to a single list.
+
+Three rules follow from this:
+
+1. **One global hook covers everything** — all methods, all paths, including static
+   assets and 404-bound requests the router matches. Not just `/api/*`.
+2. **Anonymity is enumerated** — an explicit allowlist of exact `METHOD /path` entries,
+   plus narrowly-scoped safe-method prefix rules where a plugin serves a namespace
+   (docs UI assets, the SPA shell).
+3. **Routes declare their requirement; undeclared fails closed** — a route with no
+   declared capability requires the *highest* privilege, not the lowest. A config miss
+   surfaces as an admin-only 403 someone notices, not an open endpoint nobody does.
 
 ## Dependencies
 
 ```bash
-bun add jsonwebtoken
-bun add -d @types/jsonwebtoken
+bun add jose
 ```
 
-## Environment Configuration
+Use `jose` (pure JS, WebCrypto-based, works on Bun/Node/edge) rather than
+`jsonwebtoken`.
 
-Add auth-related config to your env plugin:
+## Route Capability Declarations
+
+Each route declares what it requires via Fastify's route `config`, typed through
+declaration merging on `FastifyContextConfig`:
 
 ```typescript
-// src/plugins/env.ts
-const schema = {
-  type: 'object',
-  required: ['JWT_SECRET'],
-  properties: {
-    JWT_SECRET: {
-      type: 'string',
-      minLength: 32,
-      description: 'Secret key for JWT signing'
-    },
-    JWT_ISSUER: {
-      type: 'string',
-      default: 'my-app'
-    },
-    JWT_AUDIENCE: {
-      type: 'string',
-      default: 'my-app-users'
-    },
-    JWT_EXPIRES_IN: {
-      type: 'string',
-      default: '24h'
-    }
+// src/auth/gateway.ts
+
+/** What a route requires. Extend to fit your domain — the shape that
+ *  matters is: routes declare, the gateway enforces. */
+export type RouteCapability =
+  | { kind: 'viewer' }                        // any authenticated principal
+  | { kind: 'operator'; targetEnv: (req: FastifyRequest) => string }
+  | { kind: 'admin' }
+
+export const CAP_VIEWER: RouteCapability = { kind: 'viewer' }
+export const CAP_ADMIN: RouteCapability = { kind: 'admin' }
+
+/** operator on the environment named by a route param */
+export function operatorOnEnvParam(paramName = 'env'): RouteCapability {
+  return {
+    kind: 'operator',
+    targetEnv: (req) => (req.params as Record<string, string>)[paramName] ?? ''
   }
 }
 
 declare module 'fastify' {
-  interface FastifyInstance {
-    config: {
-      JWT_SECRET: string
-      JWT_ISSUER: string
-      JWT_AUDIENCE: string
-      JWT_EXPIRES_IN: string
-      // ... other config
-    }
+  interface FastifyContextConfig {
+    capability?: RouteCapability
   }
-}
-```
 
-## Auth Middleware
-
-### Bearer Token Extraction
-
-```typescript
-// src/middleware/auth.ts
-import { FastifyRequest } from 'fastify'
-
-function extractBearerToken(request: FastifyRequest): string | null {
-  const authHeader = request.headers.authorization
-  if (!authHeader) return null
-
-  const parts = authHeader.split(' ')
-  if (parts.length !== 2 || parts[0].toLowerCase() !== 'bearer') {
-    return null
-  }
-  return parts[1]
-}
-```
-
-### JWT Payload Type
-
-```typescript
-export interface JWTPayload {
-  sub: string           // User ID
-  email: string
-  groups: string[]      // Roles/permissions
-  iat: number          // Issued at
-  exp: number          // Expiration
-}
-
-// Extend FastifyRequest to include user
-declare module 'fastify' {
   interface FastifyRequest {
-    user?: JWTPayload
+    /** Set by the gateway once authentication succeeds. */
+    principal?: PrincipalInfo
   }
 }
 ```
 
-### Required Authentication
-
-Use when endpoint requires a valid token:
+Routes declare their capability in `config` — visible right where the route is defined,
+and machine-checkable:
 
 ```typescript
-import jwt from 'jsonwebtoken'
-import { FastifyRequest, FastifyReply } from 'fastify'
+fastify.get('/api/v1/runs', {
+  config: { capability: CAP_VIEWER },
+  schema: { /* ... */ }
+}, async (request, reply) => { /* ... */ })
 
-export async function verifyJWT(
-  request: FastifyRequest,
-  reply: FastifyReply
-): Promise<void> {
-  const token = extractBearerToken(request)
+fastify.post<{ Params: { env: string } }>('/api/v1/envs/:env/promote', {
+  config: { capability: operatorOnEnvParam('env') },
+  schema: { /* ... */ }
+}, async (request, reply) => { /* ... */ })
 
-  if (!token) {
-    reply.code(401).send({
-      success: false,
-      error: 'Authentication required'
-    })
-    return
+fastify.post('/api/v1/principals', {
+  config: { capability: CAP_ADMIN },
+  schema: { /* ... */ }
+}, async (request, reply) => { /* ... */ })
+```
+
+When the requirement derives from the request (an env named in a param, a body field,
+a path segment of a resource key), the capability carries a `targetEnv`-style resolver
+function rather than a static string — the gateway calls it against the live request.
+
+## The Anonymous Allowlist
+
+The allowlist is a small, exact, reviewable data structure — not a prefix heuristic:
+
+```typescript
+// Exact method+path entries. Health probes and any read a deploy/monitor
+// tool must hit before it can authenticate.
+const ANON_EXACT = new Set<string>([
+  'GET /health',
+  'GET /health/deep'
+])
+
+// Fastify auto-registers a HEAD twin for every GET; treat HEAD as GET.
+const SAFE_METHODS = new Set(['GET', 'HEAD'])
+
+export function isAnonymousRoute(method: string, path: string): boolean {
+  const normalized = method === 'HEAD' ? 'GET' : method
+  if (ANON_EXACT.has(`${normalized} ${path}`)) return true
+
+  // The /auth/* namespace establishes sessions and verifies its own
+  // tokens — all methods (logout/refresh are POSTs).
+  if (path === '/auth' || path.startsWith('/auth/')) return true
+
+  if (SAFE_METHODS.has(method)) {
+    // The browsable OpenAPI reference + the swagger-ui plugin's static
+    // assets under it. Safe methods only — a non-GET registered on an
+    // allowlisted path is still denied by default.
+    if (path === '/docs' || path.startsWith('/docs/')) return true
+
+    // The static SPA shell: safe-method requests outside the API and
+    // auth namespaces (index.html, /assets/*, deep-link fallbacks). The
+    // shell contains no data — everything it renders comes from the
+    // authenticated API.
+    if (path !== '/api' && !path.startsWith('/api/')) return true
   }
-
-  try {
-    // Access config through request.server, not process.env
-    const config = request.server.config
-    const decoded = jwt.verify(token, config.JWT_SECRET, {
-      issuer: config.JWT_ISSUER,
-      audience: config.JWT_AUDIENCE
-    }) as JWTPayload
-
-    request.user = decoded
-  } catch (error) {
-    request.log.debug({ error }, 'JWT verification failed')
-    reply.code(401).send({
-      success: false,
-      error: 'Invalid or expired token'
-    })
-  }
+  return false
 }
 ```
 
-### Optional Authentication
+Key points:
 
-Use when endpoint works with or without authentication:
+- **Exact entries are the norm.** Each prefix rule must be tied to a namespace a plugin
+  owns (`/docs/*` static assets, the SPA shell) and restricted to safe methods.
+- **HEAD normalizes to GET** so the auto-registered HEAD twins don't fall through.
+- The allowlist is trivially unit-testable — write regression tests asserting exactly
+  which `(method, path)` pairs are anonymous.
+
+## The Global Gateway Hook
+
+One `preHandler` authenticates and authorizes every matched request:
 
 ```typescript
-export async function optionalAuth(
-  request: FastifyRequest,
-  reply: FastifyReply
-): Promise<void> {
-  const token = extractBearerToken(request)
+async function authorizeRequest(
+  req: FastifyRequest,
+  reply: FastifyReply,
+  /* your principal-resolution deps */
+): Promise<boolean> {
+  const path = req.url.split('?')[0] ?? req.url
+  if (isAnonymousRoute(req.method, path)) return true
 
-  if (!token) {
-    // No token is fine, continue without user
-    return
+  // 1. Authenticate: resolve exactly one principal from one transport.
+  const resolved = await resolveApiPrincipal(req)
+  if (!resolved) {
+    reply.status(401).send({ error: 'unauthorized' })
+    return false
   }
 
-  try {
-    const config = request.server.config
-    const decoded = jwt.verify(token, config.JWT_SECRET, {
-      issuer: config.JWT_ISSUER,
-      audience: config.JWT_AUDIENCE
-    }) as JWTPayload
-
-    request.user = decoded
-  } catch (error) {
-    // Invalid token with optional auth - log but continue
-    request.log.debug({ error }, 'Optional auth token invalid, continuing without user')
+  // 2. CSRF: only cookie-authenticated state-changing requests (see below).
+  if (
+    resolved.transport === 'cookie' &&
+    STATE_CHANGING_METHODS.has(req.method) &&
+    !hasCsrfHeader(req.headers)
+  ) {
+    reply.status(403).send({ error: 'csrf_header_required' })
+    return false
   }
+
+  req.principal = resolved.principal
+
+  // 3. Authorize against the route's declared capability.
+  //    FAIL CLOSED: no declaration means the highest requirement, not open.
+  const capability: RouteCapability =
+    (req.routeOptions.config as { capability?: RouteCapability } | undefined)
+      ?.capability ?? CAP_ADMIN
+
+  if (capability.kind === 'viewer') return true
+
+  const targetEnv =
+    capability.kind === 'operator' ? capability.targetEnv(req) : undefined
+
+  if (hasCapability(resolved.principal, capability, targetEnv)) return true
+
+  reply.status(403).send({
+    error: 'forbidden',
+    required: capability.kind,
+    ...(targetEnv !== undefined ? { environment: targetEnv } : {}),
+    your_role: effectiveRoleFor(resolved.principal, capability, targetEnv)
+  })
+  return false
 }
-```
 
-### Group-Based Authorization
-
-Require specific groups/roles:
-
-```typescript
-export function requireGroups(requiredGroups: string[]) {
-  return async function (
-    request: FastifyRequest,
-    reply: FastifyReply
-  ): Promise<void> {
-    // First verify the JWT
-    await verifyJWT(request, reply)
-
-    // If verifyJWT sent a response, stop
-    if (reply.sent) return
-
-    // Check if user has at least one required group
-    const hasRequiredGroup = requiredGroups.some(
-      group => request.user!.groups.includes(group)
-    )
-
-    if (!hasRequiredGroup) {
-      reply.code(403).send({
-        success: false,
-        error: 'Insufficient permissions',
-        required: requiredGroups,
-        actual: request.user!.groups
+export function registerAuthzGateway(app: FastifyInstance /*, deps */) {
+  // Callback-style registration is deliberate — see gotchas.md: an async
+  // hook that calls reply.send() and returns does NOT reliably stop the
+  // request under every runtime. done() is only called on the allow path.
+  app.addHook('preHandler', (req, reply, done) => {
+    authorizeRequest(req, reply)
+      .then((shouldContinue) => {
+        if (shouldContinue) done()
+        // else: 401/403 already sent — do NOT call done(), which would
+        // resume the chain and run the handler after the reply.
       })
-      return
-    }
+      .catch((err) => done(err as Error))
+  })
+}
+```
+
+The error contract distinguishes two failures, never conflated:
+
+- **`401 Unauthorized`** — no valid principal (missing/expired/revoked token). The
+  browser app treats this as "redirect to login."
+- **`403 Forbidden`** — authenticated but under-privileged. The body names the
+  requirement, the target, and the caller's effective role
+  (`{error: "forbidden", required, environment, your_role}`) so the UI can render a
+  specific message instead of a generic denial.
+
+**Always register the gateway.** There is no auth-optional mode, no boolean that skips
+registration. Local development substitutes the principal instead (see below).
+
+## Sessions
+
+### Never return the token in the response body
+
+The classic anti-pattern: `POST /login` returns `{ token }` for the client to stash in
+localStorage. That token is JS-readable — any XSS exfiltrates it. Instead, the login
+flow *sets a cookie* and the response body carries only display data:
+
+| Attribute | Value | Why |
+| ----------- | ------- | ----- |
+| Name | `__Secure-<app>_session` | The `__Secure-` prefix requires `Secure`, blocking downgrade tricks |
+| `HttpOnly` | yes | JS cannot read the token — XSS can't exfiltrate it |
+| `Secure` | yes | HTTPS only |
+| `SameSite` | `Lax` | Cookies still flow to same-site API calls; combined with the CSRF header below |
+| `Path` | `/` | |
+| `Domain` | `.<apex-domain>` when the API is on a subdomain; omit for host-only |
+
+Because the cookie is httpOnly, the frontend can't read claims from the JWT — expose a
+`GET /auth/session` endpoint returning the validated principal's identity + display
+claims + **live** role/grants.
+
+On a plain-http local origin the `__Secure-` prefix is unusable (it requires `Secure`,
+which requires HTTPS) — fall back to an unprefixed, non-Secure cookie name when the
+configured base URL is http.
+
+### CSRF: custom header on cookie-authenticated writes
+
+`SameSite=Lax` alone doesn't cover same-site subdomain cases or every legacy browser.
+Require a custom header (e.g. `X-MYAPP-CSRF: 1`) on every **state-changing**
+(POST/PUT/PATCH/DELETE) request authenticated **by cookie**. Only same-origin JS can
+set a custom header; a cross-site form POST cannot.
+
+**Bearer-authenticated requests are exempt** — CSRF rides *ambient* credentials the
+browser attaches automatically, and an attacker can't set an `Authorization` header
+cross-site. Applying the CSRF check to Bearer traffic just breaks curl and CI for no
+security gain. Reads (GET/HEAD) are exempt too — they're CSRF-safe by definition
+(assuming your GETs are actually side-effect-free).
+
+### JWT as format, database as authority
+
+Use a JWT as the token *format* — but a pure stateless `jwt.verify()` is not an
+authentication authority. A signature check can't revoke anything: logout, token theft
+response, and account deactivation would all have to wait out `exp`.
+
+Instead, every issued token gets a row in a **database-backed token store**, keyed by
+the JWT's `jti`:
+
+| Field | Description |
+| ------- | ------------- |
+| `id` | Token id (`jti` in the JWT) — the revocation handle |
+| `principal_id` | Owning principal |
+| `kind` | `user` (cookie session) \| `service_account` (Bearer) |
+| `created_at`, `expires_at` | Lifetime bounds |
+| `revoked_at` | Non-null once logged out / revoked / principal deactivated |
+
+Per request: verify signature + `exp` (a **fast pre-check** that filters garbage before
+touching the DB), then validate live — row exists, not revoked, not expired, owning
+principal active. Any failure → 401. The signature alone is never sufficient. This is
+what turns logout and deactivation into *immediate* effects.
+
+```typescript
+export async function resolveSession(cookieHeader: string | undefined) {
+  const token = parseCookies(cookieHeader)[SESSION_COOKIE_NAME]
+  if (!token) return null
+  const claims = await verifySessionJwt(token)   // signature + exp: fast pre-check
+  if (!claims || claims.kind !== 'user') return null
+  const result = await tokenStore.validate(claims.jti)  // THE authority
+  if (!result?.valid || !result.principal) return null
+  return { claims, principal: result.principal }
+}
+```
+
+### Authorization from live state, never token claims
+
+The JWT may carry `role`/`name`/`email` claims — treat them as **display hints only**,
+for cheap frontend rendering. Enforcement always reads the principal's live authority
+(role + grants) from the store, resolved per request. WHY: claims are a snapshot at
+mint time; if authorization reads them, a demoted or deactivated user keeps their old
+powers until the token expires. Live resolution makes role changes and offboarding take
+effect on the very next request, with no restart and no token invalidation dance.
+
+## Multiple Credential Transports
+
+Humans and machines authenticate differently; support both, resolved to the same
+principal model:
+
+| Principal | Transport | CSRF |
+|-----------|-----------|------|
+| **User** (browser) | `__Secure-` session cookie | Needs the custom-header defense |
+| **Service account** (automation) | `Authorization: Bearer <jwt>` | Immune — exempt |
+
+**Each transport is terminal.** Resolution checks transports in a fixed order, and once
+a request *presents* a given transport (the header is there), resolution either succeeds
+via that transport or the request fails — it never falls back to trying the next one:
+
+```typescript
+export async function resolveApiPrincipal(req: FastifyRequest) {
+  const authHeader = req.headers.authorization
+  if (authHeader) {
+    // Bearer presented: succeed as Bearer or fail. No cookie fallback.
+    const resolved = await resolveBearerPrincipal(authHeader)
+    return resolved ? { principal: resolved.principal, transport: 'bearer' as const } : null
   }
+  const session = await resolveSession(req.headers.cookie)
+  return session ? { principal: session.principal, transport: 'cookie' as const } : null
 }
 ```
 
-## Using Auth in Routes
+And enforce token `kind` per transport: a `user`-kind token is accepted **only** from
+the cookie; a `service_account`-kind token **only** from the `Authorization` header.
 
-### Protected Route
+WHY: fallback creates confused-deputy holes. If a bad Bearer token silently falls
+through to the browser's ambient cookie, a page's fetch with a stale/garbage
+`Authorization` header still acts as the logged-in user — and a leaked JS-readable copy
+of a user token could be replayed as a Bearer credential. Wrong transport → rejected,
+full stop.
+
+## Local Development Mode
+
+Local development (especially ephemeral instances spun up by coding agents) must not
+require an IdP, a client secret, or a login click. The **wrong** way to get there is
+"just don't register the auth hook in dev" — that creates an auth-optional code path,
+forks every route into two behaviors, and is one misconfigured env var away from
+serving production traffic open.
+
+Instead, an explicit `AUTH_DISABLED` mode that **substitutes the principal, never the
+enforcement**:
 
 ```typescript
-import { verifyJWT } from '../middleware/auth'
-
-const routes: FastifyPluginAsync = async (fastify, opts) => {
-  // Single route protection
-  fastify.get('/profile', {
-    preHandler: verifyJWT
-  }, async (request, reply) => {
-    // request.user is guaranteed to exist
-    const userId = request.user!.sub
-    return { success: true, data: { userId } }
-  })
-}
+const resolved =
+  authMode.mode === 'disabled'
+    ? { principal: DEV_PRINCIPAL, transport: 'dev' as const }  // synthetic dev admin
+    : await resolveApiPrincipal(req)
 ```
 
-### Route with Role Requirement
+- **The gateway still runs.** Every request resolves to a fixed synthetic dev-admin
+  principal and then flows through the exact same capability checks as production —
+  deny-by-default, fail-closed, and the 401/403 contract are all exercised identically.
+- **Boot contract: exactly one mode.** The service requires exactly one of
+  `OIDC_ISSUER_URL` (enforced) or `AUTH_DISABLED=1` (dev). Neither → refuse to boot
+  with a message naming both options. Both → refuse to boot (ambiguous intent is a
+  misconfiguration, not a precedence question). There is deliberately no third
+  "no auth configured" state.
+- **Strict tri-state parse.** `AUTH_DISABLED` accepts `1/true/yes` or `0/false/no`;
+  anything else **throws at boot**. A typo'd `AUTH_DISABLED=ture` silently meaning
+  either mode would be confusing at best and dangerous at worst.
+- **Loopback containment.** Under `AUTH_DISABLED` the server binds `127.0.0.1` unless
+  `HOST` is explicitly set — and widening it boots with a prominent warning.
+- **Hard refusal on deployment platforms.** If deployment-platform markers are present
+  (e.g. Cloud Run sets `K_REVISION`), boot **fails regardless** of anything else:
 
 ```typescript
-import { requireGroups } from '../middleware/auth'
-
-const adminRoutes: FastifyPluginAsync = async (fastify, opts) => {
-  fastify.delete<{ Params: { id: string } }>('/users/:id', {
-    preHandler: requireGroups(['admin'])
-  }, async (request, reply) => {
-    // Only admins can reach here
-    const { id } = request.params
-    await fastify.userService.delete(id)
-    return { success: true }
-  })
-}
-```
-
-### Optional Auth Route
-
-```typescript
-import { optionalAuth } from '../middleware/auth'
-
-const routes: FastifyPluginAsync = async (fastify, opts) => {
-  fastify.get('/items', {
-    preHandler: optionalAuth
-  }, async (request, reply) => {
-    const items = await fastify.itemService.findAll()
-
-    // Customize response based on auth status
-    if (request.user) {
-      // Authenticated users see more details
-      return { success: true, data: items }
-    } else {
-      // Anonymous users see limited data
-      return { success: true, data: items.map(i => ({ id: i.id, name: i.name })) }
-    }
-  })
-}
-```
-
-## Global Auth Hook
-
-Apply optional auth globally, then require it on specific routes:
-
-```typescript
-// In app.ts
-export const app: FastifyPluginAsync = async (fastify, opts) => {
-  await fastify.register(envPlugin)
-
-  // Global optional auth (skips health checks)
-  fastify.addHook('onRequest', async (request, reply) => {
-    if (request.raw.url?.startsWith('/api/health')) {
-      return
-    }
-    await optionalAuth(request, reply)
-  })
-
-  // Register routes - they can check request.user or use preHandler for required auth
-  await fastify.register(publicRoutes, { prefix: '/api' })
-  await fastify.register(protectedRoutes, { prefix: '/api' })
-}
-```
-
-## Token Generation
-
-Service for creating tokens:
-
-```typescript
-// src/services/auth-service.ts
-import jwt from 'jsonwebtoken'
-import bcrypt from 'bcrypt'
-import { FastifyInstance } from 'fastify'
-import { JWTPayload } from '../middleware/auth'
-
-export class AuthService {
-  constructor(private fastify: FastifyInstance) {}
-
-  generateToken(user: { id: string; email: string; groups: string[] }): string {
-    const config = this.fastify.config
-
-    const payload: Omit<JWTPayload, 'iat' | 'exp'> = {
-      sub: user.id,
-      email: user.email,
-      groups: user.groups
-    }
-
-    return jwt.sign(payload, config.JWT_SECRET, {
-      issuer: config.JWT_ISSUER,
-      audience: config.JWT_AUDIENCE,
-      expiresIn: config.JWT_EXPIRES_IN
-    })
+if (isAuthDisabled(env)) {
+  if (env.K_REVISION) {
+    throw new Error(
+      'AUTH_DISABLED is set in a Cloud Run environment (K_REVISION present) — the ' +
+      'local-development bypass must never serve deployed traffic; unset AUTH_DISABLED ' +
+      'and configure OIDC'
+    )
   }
-
-  async validateCredentials(email: string, password: string): Promise<User | null> {
-    // Note: Requires userService to be decorated on fastify instance before AuthService is used
-    const user = await this.fastify.userService.findByEmail(email)
-    if (!user) return null
-
-    const valid = await this.comparePassword(password, user.passwordHash)
-    if (!valid) return null
-
-    return user
-  }
-
-  private async comparePassword(plain: string, hash: string): Promise<boolean> {
-    return bcrypt.compare(plain, hash)
-  }
+  // ...
 }
 ```
 
-## Login Route
+  A disabled-auth image accidentally deployed fails its health checks instead of
+  silently serving an open console.
 
-```typescript
-const authRoutes: FastifyPluginAsync = async (fastify, opts) => {
-  fastify.post<{ Body: { email: string; password: string } }>('/login', {
-    schema: {
-      body: {
-        type: 'object',
-        required: ['email', 'password'],
-        properties: {
-          email: { type: 'string', format: 'email' },
-          password: { type: 'string', minLength: 1 }
-        }
-      }
-    }
-  }, async (request, reply) => {
-    const { email, password } = request.body
+## Identity Provider Integration
 
-    const user = await fastify.authService.validateCredentials(email, password)
+Keep the skill of *establishing* identity separate from sessions and authorization.
+For human users, federate to an OIDC identity provider using the **authorization-code
+flow with PKCE** as the reference flow — do not default to local bcrypt passwords (you
+then own password storage, reset flows, MFA, and breach response; an IdP already does
+all of it, and enterprise clients will require their IdP anyway):
 
-    if (!user) {
-      reply.code(401)
-      return { success: false, error: 'Invalid credentials' }
-    }
+1. Unauthenticated browser → redirect to `GET /auth/login`.
+2. `/auth/login` redirects to the IdP authorize endpoint with `client_id`,
+   `redirect_uri`, `scope`, a PKCE `code_challenge`, an anti-forgery `state`, and a
+   `nonce`. Stash `state` + PKCE verifier + `nonce` in a short-lived signed cookie
+   (path-scoped to `/auth`) so a stateless service survives the redirect round-trip.
+3. IdP redirects back to `GET /auth/callback?code=…&state=…`.
+4. Callback validates `state` against the stash, exchanges `code` (with the PKCE
+   verifier) for the ID token, and **verifies** it: signature against the IdP JWKS,
+   issuer, audience, expiry, and the `nonce` claim against the stash.
+5. Resolve identity claims to a platform principal (provision on first sign-in if your
+   policy allows), mint a platform session token backed by a token-store row, set the
+   session cookie, redirect to the app.
 
-    const token = fastify.authService.generateToken({
-      id: user.id,
-      email: user.email,
-      groups: user.groups
-    })
-
-    return {
-      success: true,
-      data: {
-        token,
-        user: { id: user.id, email: user.email }
-      }
-    }
-  })
-}
-```
+Consume **only identity claims** (`sub`, `email`, `name`). Never read roles or groups
+from IdP claims — authority is platform state (see "live state, never token claims"
+above), which is what makes role changes immediate and keeps the platform portable
+across IdPs.
 
 ## Security Considerations
 
-1. **Never log tokens**: Ensure JWT tokens are not logged in request/response hooks
-2. **Use strong secrets**: JWT_SECRET should be at least 32 characters, randomly generated
-3. **Set appropriate expiration**: Balance security vs user experience
-4. **Validate issuer/audience**: Prevents token reuse across different applications
-5. **Use HTTPS**: Always require HTTPS in production to protect tokens in transit
+1. **Deny by default** — one global gateway; anonymity is an enumerated allowlist;
+   undeclared routes fail closed to the highest requirement
+2. **httpOnly cookies for humans** — never return tokens in response bodies for the
+   browser to store
+3. **Revocation must be possible** — DB-backed token store keyed by `jti`;
+   signature+exp is a pre-check, the store is the authority
+4. **Authorize from live state** — token claims are display hints, never enforcement
+   inputs
+5. **Transports are terminal** — wrong-transport tokens are rejected, never fall back
+6. **CSRF header on cookie-authenticated writes** — Bearer traffic exempt
+7. **Dev mode substitutes the principal, not the enforcement** — loopback-bound,
+   strict tri-state parse, hard boot refusal on deployment platforms
+8. **Never log tokens** — keep JWTs out of request/response log hooks
+9. **Strong signing keys** — HS256 needs ≥32 bytes; validate the length at boot, since
+   `sign()` failing at first login is a far worse place to find out

--- a/skills/jarvus-fastify/references/gotchas.md
+++ b/skills/jarvus-fastify/references/gotchas.md
@@ -422,6 +422,173 @@ declare module 'fastify' {
 
 ---
 
+## Async Hook Short-Circuit Under Bun `.inject()`
+
+### Problem: The Handler Runs After the Hook's 401
+
+```typescript
+// WRONG - looks correct, silently fails to short-circuit
+fastify.addHook('preHandler', async (req, reply) => {
+  const ok = await authorize(req)
+  if (!ok) {
+    reply.code(401).send({ error: 'unauthorized' })
+    return  // ...but the route handler STILL runs
+  }
+})
+```
+
+An async hook that calls `reply.send()` and returns does **not** reliably stop the
+request — observed in anger via `.inject()` on Bun: the 401 is in flight, yet the route
+handler executes anyway. Fastify only auto-relays a *route handler's* return value; for
+hooks, completion signaling through the async return path is runtime-dependent. This is
+a silent **authorization-bypass class of bug**: tests may see the 401 status while the
+protected side effect still happened.
+
+### Solution: Callback-Style Hook, done() Only on the Allow Path
+
+```typescript
+// CORRECT - done() is the only way the chain continues
+fastify.addHook('preHandler', (req, reply, done) => {
+  authorize(req, reply)
+    .then((shouldContinue) => {
+      if (shouldContinue) done()
+      // else: the reply was already sent - do NOT call done(), which
+      // would resume the chain and run the handler after the reply.
+    })
+    .catch((err) => done(err as Error))
+})
+```
+
+Register security-critical hooks callback-style `(req, reply, done)` and only call
+`done()` on the allow path — never after a reply has been sent. Add a test asserting
+the handler did NOT run (e.g. a spy on the downstream side effect), not just that the
+status code was 401.
+
+---
+
+## Environment Variable Parsing Footguns
+
+### Problem: Silently Wrong Numbers and Booleans
+
+```typescript
+// WRONG - all of these pass silently with garbage input
+const port = Number(process.env.PORT)          // "abc" -> NaN, listen() fails cryptically
+const ttl = parseInt(process.env.TTL ?? '')    // "3600abc" -> 3600, "-5" -> -5
+const debug = process.env.DEBUG === 'true'     // "TRUE", "1", "ture" all -> false, silently
+```
+
+`Number()` accepts `NaN` without complaint; `parseInt` truncates trailing garbage and
+accepts negatives; a `=== 'true'` boolean check turns any typo into a silent mode
+selection. Each surfaces far from the bad env var — as a broken `listen()`, an
+immediately-expired session, or the wrong auth mode.
+
+### Solution: Strict Parses That Throw at Boot
+
+```typescript
+// CORRECT - digit-only match, range check, named error
+function resolvePort(env: NodeJS.ProcessEnv): number {
+  const raw = env.PORT
+  if (raw === undefined || raw.trim() === '') return 8080
+  const trimmed = raw.trim()
+  if (!/^\d+$/.test(trimmed)) {
+    throw new Error(`PORT must be a positive integer (got "${raw}")`)
+  }
+  const port = parseInt(trimmed, 10)
+  if (port < 1 || port > 65535) {
+    throw new Error(`PORT must be between 1 and 65535 (got "${raw}")`)
+  }
+  return port
+}
+
+// CORRECT - strict tri-state boolean: unset, true-ish, false-ish; anything else throws
+const TRUE_VALUES = new Set(['1', 'true', 'yes'])
+const FALSE_VALUES = new Set(['', '0', 'false', 'no'])
+
+function parseBoolEnv(name: string, raw: string | undefined): boolean {
+  if (raw === undefined) return false
+  const value = raw.trim().toLowerCase()
+  if (TRUE_VALUES.has(value)) return true
+  if (FALSE_VALUES.has(value)) return false
+  throw new Error(`${name} must be one of 1/true/yes or 0/false/no (got "${raw}")`)
+}
+```
+
+The tri-state parse matters most on security-relevant flags: a typo'd value must
+**throw** rather than silently picking a mode (a typo that quietly disabled auth would
+be dangerous; one that quietly required it would be confusing).
+
+---
+
+## Accepted-but-Unenforced Config Knobs
+
+### Problem: Parsed Config That Silently Does Nothing
+
+```typescript
+// Config schema accepts SESSION_IDLE_TIMEOUT, the code parses and stores it...
+sessionIdleTimeoutSeconds: parseIntEnv('SESSION_IDLE_TIMEOUT', env.SESSION_IDLE_TIMEOUT)
+// ...but nothing enforces it yet. An operator sets it expecting idle
+// logout and gets a silent no-op with no indication anything is missing.
+```
+
+This happens naturally when config is wired ahead of the feature (spec'd but deferred).
+Rejecting the var breaks forward compatibility; accepting it silently misleads the
+operator.
+
+### Solution: Loud Boot Warning for Every Set-but-Unenforced Knob
+
+```typescript
+export function unenforcedConfigWarnings(env: NodeJS.ProcessEnv): string[] {
+  const warnings: string[] = []
+  if (env.SESSION_IDLE_TIMEOUT !== undefined) {
+    warnings.push(
+      'SESSION_IDLE_TIMEOUT is set but not yet enforced - no idle-timeout logout is applied.'
+    )
+  }
+  return warnings
+}
+
+// At boot:
+for (const warning of unenforcedConfigWarnings(process.env)) {
+  app.log.warn(warning)
+}
+```
+
+Warn only when the var is **explicitly set** — a default-derived value needs no noise.
+Say what is NOT happening ("no absolute session cap is applied"), not just that the
+knob is unwired.
+
+---
+
+## Swagger Registration Order
+
+### Problem: Deferred Swagger Register Yields an Empty Spec
+
+```typescript
+// WRONG - routes registered before swagger's onRoute hook exists
+app.register(fastifySwagger, { openapi: { /* ... */ } })  // not awaited
+registerRoutes(app)
+// GET /docs/json -> { "paths": {} }  - silently empty, no error anywhere
+```
+
+`@fastify/swagger` captures routes via an `onRoute` hook — which only sees routes added
+*after* the hook exists. A bare (deferred) `register` queues the plugin behind the route
+registration, so every route escapes capture and the document is silently empty.
+
+### Solution: Await Swagger Before Registering Routes
+
+```typescript
+// CORRECT
+await app.register(fastifySwagger, { openapi: { /* ... */ } })
+await app.register(fastifySwaggerUI, { routePrefix: '/docs' })
+
+registerRoutes(app)  // now every route is captured
+```
+
+Add a smoke test that injects `GET /docs/json` and asserts `Object.keys(body.paths)`
+is non-empty — it catches any future registration reordering.
+
+---
+
 ## Testing Considerations
 
 ### Problem: Testing Routes Without Full Server

--- a/skills/jarvus-fastify/references/patterns.md
+++ b/skills/jarvus-fastify/references/patterns.md
@@ -117,6 +117,12 @@ const routes: FastifyPluginAsync = async (fastify, opts) => {
 
 ## Service Architecture
 
+The service-class patterns in this section (and the query-building/pagination content
+in [api-design.md](api-design.md)) assume the common shape: a **DB-backed CRUD
+service** that owns its data. When the service is instead a stateless gateway over
+gRPC or another upstream API, skip the decorated service classes and use the
+[Upstream-Client Backends](#upstream-client-backends-proxy-shape) pattern below.
+
 ### Single-Responsibility Services
 
 Each service handles one domain:
@@ -206,6 +212,110 @@ export class OrderService {
 const userService = new UserService(fastify)
 const orderService = new OrderService(fastify)
 orderService.setUserService(userService)
+```
+
+## Upstream-Client Backends (Proxy Shape)
+
+Some services own no data at all — they are a thin, stateless translation layer from
+HTTP to gRPC (or to another internal API): validate the request, call the upstream,
+map the result and its error codes back to HTTP. For that shape, the decorated
+service-class pattern above is the wrong tool.
+
+### Inject the Client as an Explicit Function Parameter
+
+Pass the upstream client into route registration as a plain argument — not a fastify
+decoration:
+
+```typescript
+// src/grpc-client.ts
+export function createClient(upstreamUrl: string) {
+  // ... build and return the typed client object
+}
+export type OrchestratorClient = ReturnType<typeof createClient>
+
+// src/routes.ts - routes close over the client parameter
+export function registerRoutes(app: FastifyInstance, client: OrchestratorClient) {
+  app.get('/api/v1/status', async () => {
+    return client.getStatus()
+  })
+  // ...
+}
+
+// index.ts
+const client = createClient(process.env.UPSTREAM_URL ?? 'localhost:50051')
+registerRoutes(app, client)
+```
+
+WHY not a decoration: the dependency is visible in the function signature, TypeScript
+checks it at the call site (no declaration merging), and — the payoff — hermetic
+`app.inject()` tests become trivial: build a Fastify instance, pass a mock client,
+done. No plugin graph, no decoration ordering.
+
+### The Mock Client: Unspecified Methods REJECT
+
+Make the shared test double reject on every method a test didn't explicitly override —
+tests then *declare* their dependencies, and an unexpected upstream call fails loudly
+instead of returning `undefined`:
+
+```typescript
+// src/test-helpers.ts
+export function makeMockClient(overrides: Partial<OrchestratorClient> = {}): OrchestratorClient {
+  const noop = (): Promise<any> => Promise.reject(new Error('not mocked'))
+  return {
+    getStatus: noop,
+    getRuns: noop,
+    triggerPipeline: noop,
+    // ... every client method, all rejecting by default
+    ...overrides
+  }
+}
+
+// In a test
+const app = buildApp(makeMockClient({
+  getStatus: async () => ({ connected_workers: 3 })
+}))
+const res = await app.inject({ method: 'GET', url: '/api/v1/status' })
+```
+
+### Map Upstream Error Codes to HTTP Deliberately
+
+Don't let upstream errors fall through as generic 500s. Maintain one explicit mapping
+from gRPC status codes to HTTP in the route layer:
+
+| gRPC code | HTTP | Meaning |
+| ----------- | ------ | --------- |
+| `INVALID_ARGUMENT` (3) | 400 | Caller sent a bad value — relay the upstream message |
+| `NOT_FOUND` (5) | 404 | Resource doesn't exist |
+| `FAILED_PRECONDITION` (9) | 503 | Upstream not ready to serve this (e.g. no leader) |
+| `ABORTED` (10) | 409 | Domain conflict — upstream sends a JSON payload in `details`; parse it and relay as the 409 body |
+
+The `ABORTED` row is the interesting one: use it as the channel for structured domain
+rejections. The upstream packs a JSON body (e.g. `{"error": "env_promote_only", ...}`)
+into the error details; the route parses it defensively and returns it as the HTTP 409
+body, so API clients get a branchable `error` discriminator instead of a stringly
+message:
+
+```typescript
+function envPromoteOnlyBody(err: any): Record<string, unknown> | null {
+  if (err?.code !== 10) return null // gRPC ABORTED
+  try {
+    const parsed = JSON.parse(err.details ?? err.message ?? '')
+    return parsed?.error === 'env_promote_only' ? parsed : null
+  } catch {
+    return null
+  }
+}
+
+app.patch('/api/v1/pipelines/:env/:id', async (request, reply) => {
+  try {
+    return await client.updatePipeline(/* ... */)
+  } catch (err: any) {
+    const promoteOnly = envPromoteOnlyBody(err)
+    if (promoteOnly) return reply.status(409).send(promoteOnly)
+    if (err?.code === 5) return reply.status(404).send({ error: 'not found' })
+    throw err // anything unmapped is a real 500
+  }
+})
 ```
 
 ## Structured Logging

--- a/skills/jarvus-fastify/references/setup-guide.md
+++ b/skills/jarvus-fastify/references/setup-guide.md
@@ -193,6 +193,26 @@ LOG_LEVEL=info
 - `dotenv: true` automatically loads `.env` file
 - Failed validation prevents server from starting
 
+**When JSON Schema isn't enough.** `@fastify/env` validates each variable in isolation —
+JSON Schema cannot express:
+
+- **Cross-field contracts** — "exactly one of `OIDC_ISSUER_URL` or `AUTH_DISABLED=1`
+  must be set; both or neither is a boot error"
+- **Environment-detection guards** — "refuse to boot if `AUTH_DISABLED` is set while
+  Cloud Run markers (`K_REVISION`) are present"
+- **Strict tri-state booleans** — unset / true-ish / false-ish, where a typo'd value
+  throws instead of silently picking a mode (schema `enum` gets close, but not the
+  "unset means X" + normalization + custom error message combination)
+- **Value-quality checks with actionable errors** — "must be a well-formed https URL",
+  "signing key must be ≥32 bytes because HS256 requires a 256-bit key"
+
+For those, write a plain `resolveConfig(env: NodeJS.ProcessEnv)` function that throws
+with an **actionable message** (name the variable, show the offending value, say what
+would fix it) and call it at boot before anything else. Keep `@fastify/env` for the
+simple per-variable cases; hand-rolled fail-fast validation is the right tool for the
+contracts above — not a workaround. See gotchas.md "Environment Variable Parsing
+Footguns" for the strict number/boolean parses.
+
 **Commit:** `feat(backend): add environment configuration plugin`
 
 ---
@@ -516,6 +536,60 @@ export default defineConfig({
 ```
 
 **Commit:** `config: add Vite proxy for backend API requests`
+
+---
+
+## Serving a Built SPA
+
+When the backend also serves the frontend's production build (one deployable unit),
+use `@fastify/static` plus an index.html not-found fallback:
+
+```bash
+bun add @fastify/static
+```
+
+```typescript
+// In index.ts, after routes are registered
+import fastifyStatic from '@fastify/static'
+import { existsSync } from 'node:fs'
+import path from 'node:path'
+
+const uiDist = process.env.UI_DIST_PATH ?? path.join(import.meta.dir, 'ui', 'dist')
+if (existsSync(uiDist)) {
+  app.register(fastifyStatic, { root: uiDist })
+  app.setNotFoundHandler((req, reply) => {
+    if (req.method === 'GET' && !req.url.startsWith('/api/')) {
+      return reply.sendFile('index.html')
+    }
+    reply.status(404)
+    return { error: 'not found' }
+  })
+} else {
+  app.log.warn(`UI dist not found at ${uiDist} — serving API only`)
+}
+```
+
+**Key patterns:**
+
+- **API routes win by specificity** — the router prefers the more specific `/api/*`
+  routes over the static plugin's wildcard route, so no ordering tricks are needed
+- **The index.html fallback is REQUIRED, not a convenience** — an SPA with
+  browser/history routing means every deep link and refresh to a client route
+  (e.g. `/run/123`) misses the static files and must boot the SPA from `index.html`;
+  API misses still get a JSON 404
+- **Graceful API-only mode** — when the dist dir is absent (dev, or a backend-only
+  build) the server logs a warning and runs API-only instead of crashing; local
+  frontend dev uses the Vite proxy above
+
+**Interaction with a global auth hook:** the static plugin registers a wildcard route,
+so the global auth gateway DOES see every static-asset request — they don't bypass
+hooks. Your anonymous allowlist must therefore cover safe-method (GET/HEAD) requests
+outside the API and auth namespaces, or the SPA shell can never load for an
+anonymous visitor who needs it to reach the login redirect. See authentication.md
+"The Anonymous Allowlist" — the shell is safe to serve anonymously because it contains
+no data; everything it renders comes from the authenticated API.
+
+**Commit:** `feat(backend): serve built SPA with history-routing fallback`
 
 ---
 


### PR DESCRIPTION
## Summary

A gap analysis of the jarvus-fastify skill against a production Fastify service (continuous-gtfs `services/web`) — plus a security review that traced the skill's prescribed patterns directly to real vulnerabilities — drove this rewrite and extension.

### `references/authentication.md` — rewritten wholesale
The old file taught an allow-by-default global hook with per-route opt-in protection, JWTs returned in the response body for the client to store, pure stateless `jwt.verify` with no revocation, authorization from token claims, bcrypt local passwords, and no CSRF guidance. The exact opt-in model it prescribed produced an unauthenticated admin-CRUD hole in the reviewed service. Replaced with:

- **Deny by default; anonymity enumerated** — one global gateway hook over the whole surface, an explicit anonymous allowlist (exact method+path entries; safe-method-only prefix rules), routes declaring their required capability via Fastify route `config` (`FastifyContextConfig` declaration merging), undeclared routes failing closed to the highest requirement
- **Sessions** — httpOnly `__Secure-` cookies (never JS-readable tokens), SameSite=Lax + custom-header CSRF on cookie-authenticated writes (Bearer exempt), JWT as format but a database-backed revocable token store (keyed by `jti`) as the authentication authority; authorization always resolved from live state, never token claims
- **Terminal credential transports** — cookie for humans, Bearer for machines; wrong-transport tokens rejected, never falling back (confused-deputy prevention)
- **Local dev mode** — `AUTH_DISABLED` substitutes the principal (synthetic dev admin through the same enforcement), loopback bind, hard boot refusal on deployment-platform markers; explicit warning against "just don't register the hook"
- OIDC auth-code+PKCE as the reference IdP flow, replacing bcrypt-as-default

### `references/gotchas.md` — four additions
- Async-hook short-circuit failure under Bun `.inject()` (silent authz-bypass class; callback-style hooks, `done()` only on allow)
- `Number`/`parseInt` env parsing footguns + strict tri-state boolean parse
- Boot warnings for accepted-but-unenforced config knobs
- Swagger must be awaited before route registration (onRoute capture)

### `references/patterns.md` — proxy-backend shape
Upstream-client backends (stateless gRPC-proxy): client injected as an explicit function parameter, reject-by-default mock client for hermetic `inject()` tests, and a deliberate gRPC-code→HTTP mapping (INVALID_ARGUMENT→400, NOT_FOUND→404, FAILED_PRECONDITION→503, ABORTED with JSON domain payload→409). Names the DB-backed-CRUD assumption the existing service-class content makes.

### Softened absolutes + SPA serving
- `{success, data, error}` envelope now presented as one option; structured domain-specific error bodies (e.g. `{error: "forbidden", required, environment, your_role}`) are equally valid and often spec-mandated (SKILL.md, api-design.md)
- "When JSON Schema isn't enough" note in setup-guide: hand-rolled fail-fast config validation for cross-field contracts, environment guards, tri-state booleans
- New setup-guide section on serving a built SPA (`@fastify/static` + index.html fallback, API-wins-by-specificity, graceful API-only mode, and the interaction with a global auth hook / anonymous allowlist)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VZrUa8ajYuSGwbsnvTCkkH