### PR TITLE
docs(agent-dev-workflow): shared-aux-services stance, multi-backend ports, self-migrating apps, PG18 variant

### DIFF
--- a/skills/agent-dev-workflow/SKILL.md
+++ b/skills/agent-dev-workflow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agent-dev-workflow
-description: Set up an agent-friendly local dev workflow — a bin/ task-runner (inspired by GitHub's scripts-to-rule-them-all) over a shared Postgres container that gives every git worktree its own isolated database and port, plus a dedicated test database so tests never clobber dev data. Use this whenever a project needs worktree-isolated local development, when setting up for AI agent orchestrators (Conductor and similar) that spin up a worktree per session and register setup/run/cleanup commands, when multiple copies of a backend must run concurrently on one machine, when replacing a docker-compose-for-local-postgres setup, or when tests keep wiping local dev/demo data. Triggers on "bin/ scripts", "worktree isolation", "per-worktree database/port", "scripts to rule them all", "agent dev environment", "setup/run/cleanup scripts", or tests clobbering the dev database.
+description: Set up an agent-friendly local dev workflow — a bin/ task-runner (inspired by GitHub's scripts-to-rule-them-all) over a shared Postgres container that gives every git worktree its own isolated database and ports, plus a dedicated test database so tests never clobber dev data. Use this whenever a project needs worktree-isolated local development, when setting up for AI agent orchestrators (Conductor and similar) that spin up a worktree per session and register setup/run/cleanup commands, when multiple copies of a backend must run concurrently on one machine, when replacing a docker-compose-for-local-postgres setup, when deciding whether auxiliary dev services (a validator container, a local OIDC IdP) replicate per worktree or run shared, or when tests keep wiping local dev/demo data. Triggers on "bin/ scripts", "worktree isolation", "per-worktree database/port", "scripts to rule them all", "agent dev environment", "setup/run/cleanup scripts", "shared auxiliary services", or tests clobbering the dev database.
 ---
 
 # Agent-friendly dev workflow (bin/ + worktree isolation)
@@ -26,14 +26,21 @@ a separate DB, the payoff is small.
 ## The core idea: identity derives from the worktree
 
 One shared Postgres container (started once, reused by name — path-independent, so
-it survives worktree deletion). Each context gets a **database** and a **port**
-derived from its worktree path:
+it survives worktree deletion). Each context gets a **database** and a **port per
+process it runs**, derived from its worktree path:
 
-| Context | Database | Backend port |
-|---|---|---|
-| Main checkout | the canonical name (durable dev data) | the default (e.g. 4000) |
-| Each agent worktree | `app_<hash-of-path>` (isolated) | next free port |
+| Context | Database | Port(s) |
+| --- | --- | --- |
+| Main checkout | the canonical name (durable dev data) | the default(s) (e.g. 4000) |
+| Each agent worktree | `app_<hash-of-path>` (isolated) | next free in each range |
 | The test runner | `app_test` (forced) | n/a |
+
+A worktree isn't necessarily one process: a repo may run an HTTP API + a gRPC
+service + a Vite frontend per worktree. The pattern generalizes cleanly — the
+project's port band claims **one range per process kind**, `_common.sh` grows one
+picker per kind, and `bin/setup` emits every derived port **plus the wiring vars
+that connect the processes** (e.g. `ORCHESTRATOR_URL`). One note: gRPC ports
+aren't curl-checkable — readiness-probe them with a plain TCP check.
 
 Because identity comes from the path, two sessions never collide and re-running
 setup is idempotent. Every derived value has an env override (`APP_DATABASE`,
@@ -57,11 +64,12 @@ know which parts you copy verbatim and which you adapt.
 **Project-specific** (the knobs you set):
 
 - the prefix, PG user/password/image, container/volume names
-- the **base port band** — the default PG port plus the backend/frontend worktree
-  ranges. This is the project's claim on the machine: worktree isolation keeps a
-  project's *own* copies apart, but the base band is what keeps *different projects*
-  from colliding when several run at once. Pick a distinct, uncommon band per repo
-  (see gotchas) and keep PG + backend + frontend in one coherent range.
+- the **base port band** — the default PG port plus one worktree range **per
+  process kind** (backend HTTP, gRPC, frontend, …). This is the project's claim on
+  the machine: worktree isolation keeps a project's *own* copies apart, but the
+  base band is what keeps *different projects* from colliding when several run at
+  once. Pick a distinct, uncommon band per repo (see gotchas) and keep PG + every
+  process range in one coherent band.
 - the Postgres **major** — pin the same one production runs (`references/snapshots.md`)
 - `app_server_dir` — repo root (single package) vs a subdir (monorepo)
 - `app_migrate` — how migrations run → **`references/migrations-and-seeds.md`**
@@ -70,6 +78,34 @@ know which parts you copy verbatim and which you adapt.
 - the **seed posture** — synthetic SQL, snapshot-as-seed, or empty + per-suite
   fixtures (`references/migrations-and-seeds.md`), and whether it has prod snapshots
   at all (`references/snapshots.md`)
+- whether the repo has **auxiliary services** and what shared endpoints to seed
+  into worktree envs (next section)
+
+## Auxiliary services: shared per machine, never per worktree
+
+What replicates per worktree is **the app + its database — nothing more**.
+Auxiliary services (a GTFS validator container, a local OIDC IdP, a fake object
+store) run **once per machine** and are shared by every worktree instance; each
+worktree's env just points at the shared endpoints. N worktrees hitting one
+validator is fine — one container instead of N is the difference between "docker
+is fine" and "my laptop is swapping".
+
+This fixes the docker-compose question cleanly:
+
+- **No aux services** (the dev flow is just app + DB) → **no compose at all**.
+  `bin/` owns the shared Postgres container directly, as prescribed.
+- **Aux services exist** → compose covers **only those**: `docker compose up -d`
+  once per machine. The compose file never contains the per-worktree app or
+  Postgres — those stay with `bin/`.
+
+Don't expand `bin/` into orchestrating aux containers; hold the boundary instead:
+**`bin/` = per-worktree identity** (DB, ports, app processes); **compose =
+machine-wide singletons**.
+
+**Env seeding** is the connective tissue: `bin/setup` emits the shared endpoints
+alongside the per-worktree values (e.g. `VALIDATOR_URL=http://localhost:9010`,
+overridable via env like everything else), so one stdout capture threads into the
+run step and every worktree converges on the same shared services.
 
 ## Build order
 
@@ -87,8 +123,10 @@ know which parts you copy verbatim and which you adapt.
    DB-backed test suite: it's the step that stops tests wiping dev data. It's a clean
    add later, but if you know tests are coming, scaffolding `bin/test` + the preload
    up front means the *first* test is born-isolated.
-6. `chmod +x bin/*` (not `_common.sh`). Remove any `docker-compose.yml` that only
-   templated local Postgres, and update `.env.example` + the project's agent docs
+6. `chmod +x bin/*` (not `_common.sh`). If a `docker-compose.yml` exists, evict
+   its Postgres (and app) services — delete the file outright if that's all it had;
+   keep it only as the once-per-machine aux-services runner (see "Auxiliary
+   services" and gotchas). Update `.env.example` + the project's agent docs
    (CLAUDE.md or equivalent) to point at `bin/`.
 7. **Verify** end to end (don't assume): `bin/setup` on a clean checkout; the
    sentinel-row test from `test-isolation.md`; `bin/dev` twice concurrently lands on
@@ -98,7 +136,7 @@ know which parts you copy verbatim and which you adapt.
 ## Reference files
 
 | File | Read when |
-|---|---|
+| --- | --- |
 | `references/bin/` | always — the script templates you copy + adapt |
 | `references/test-isolation.md` | wiring tests to `app_test` (the preload), **and** authoring suites against it (in-process `inject`, scoped truncate, fixtures) — almost always |
 | `references/migrations-and-seeds.md` | setting `app_migrate`; deciding on seeds |
@@ -118,6 +156,11 @@ preload's `??=` is the handshake that lets CI's explicit `DATABASE_URL` win. Ado
 both together for a DB-backed app — the CI skill defines the gate, this skill keeps
 it from clobbering dev data. (SquadQuest is the worked example: a `"test": "bun test"`
 script, `bin/test`, and a `bunfig.toml` preload that defers via `??=`.)
+
+Some repos deliberately run CI with **no database at all** (live-DB suites
+self-skip). That's a legitimate posture too — but the preload must then skip
+when Postgres is unreachable instead of failing the run. See
+`test-isolation.md` §CI for both postures.
 
 ## Guardrails
 

--- a/skills/agent-dev-workflow/references/bin/_common.sh
+++ b/skills/agent-dev-workflow/references/bin/_common.sh
@@ -13,7 +13,12 @@ set -euo pipefail
 
 APP_PG_USER="app"
 APP_PG_PASSWORD="app"
-APP_PG_IMAGE="postgres:17-alpine"     # see gotchas.md before choosing 18
+# Pin the SAME Postgres major production runs (see gotchas.md). postgres:18
+# moved the data directory — if prod is 18, change BOTH lines together:
+#   APP_PG_IMAGE="postgres:18-alpine"
+#   APP_PG_DATA_DIR="/var/lib/postgresql"        # NOT .../data on 18
+APP_PG_IMAGE="postgres:17-alpine"
+APP_PG_DATA_DIR="/var/lib/postgresql/data"
 APP_CONTAINER_NAME="app-postgres"
 APP_VOLUME_NAME="app-pgdata"
 
@@ -67,6 +72,17 @@ app_database_url() {
   echo "postgres://${APP_PG_USER}:${APP_PG_PASSWORD}@localhost:$(app_pg_port)/$(app_db_name)"
 }
 
+# Not every app reads DATABASE_URL — some consume discrete DB_HOST/DB_PORT/…
+# vars. Emit BOTH forms from bin/setup (uncomment there), or better: teach the
+# app DATABASE_URL with a discrete-var fallback so one URL rules everywhere.
+app_db_env() {
+  echo "DB_HOST=localhost"
+  echo "DB_PORT=$(app_pg_port)"
+  echo "DB_NAME=$(app_db_name)"
+  echo "DB_USER=${APP_PG_USER}"
+  echo "DB_PASSWORD=${APP_PG_PASSWORD}"
+}
+
 # ── Shared Postgres container ────────────────────────────────────────────────
 ensure_postgres() {
   local container="$APP_CONTAINER_NAME" port
@@ -84,7 +100,7 @@ ensure_postgres() {
       -e POSTGRES_USER="$APP_PG_USER" \
       -e POSTGRES_PASSWORD="$APP_PG_PASSWORD" \
       -e POSTGRES_DB=app \
-      -v "${APP_VOLUME_NAME}:/var/lib/postgresql/data" \
+      -v "${APP_VOLUME_NAME}:${APP_PG_DATA_DIR}" \
       "$APP_PG_IMAGE" >/dev/null
   fi
   wait_for_postgres
@@ -171,3 +187,16 @@ app_pick_port() {
   if ! port_in_use 4000; then echo "4000"; return; fi
   find_available_port 4001 4099
 }
+
+# Multi-process backends: a worktree may run SEVERAL processes (HTTP API + gRPC
+# service + Vite, …). Add one picker PER PROCESS KIND, each with a DISJOINT range
+# inside the project's band (e.g. HTTP 4000-4049, gRPC 4050-4099, Vite 4100-4199 —
+# shrink app_pick_port's range to match), and have bin/setup emit every derived
+# port plus the wiring vars between them (e.g. ORCHESTRATOR_URL). Readiness note:
+# gRPC ports aren't curl-checkable — probe with a plain TCP check, e.g.
+# `(exec 3<>"/dev/tcp/127.0.0.1/$port") 2>/dev/null`.
+# app_pick_grpc_port() {
+#   if [ -n "${GRPC_PORT:-}" ]; then echo "$GRPC_PORT"; return; fi
+#   if ! port_in_use 4050; then echo "4050"; return; fi
+#   find_available_port 4051 4099
+# }

--- a/skills/agent-dev-workflow/references/bin/dev-fullstack
+++ b/skills/agent-dev-workflow/references/bin/dev-fullstack
@@ -26,14 +26,29 @@ echo "Backend:  http://localhost:${PORT}" >&2
 pidfile="$root/.dev.pid"
 echo $$ > "$pidfile"
 
-# kill 0 signals the whole process group → both children die when this script exits.
+# kill 0 signals the whole process group → all children die when this script exits.
 trap 'rm -f "$pidfile"; kill 0' EXIT
 
-# Backend
-env DATABASE_URL="$DATABASE_URL" PORT="$PORT" HOST="${HOST:-0.0.0.0}" \
+# Backend. HOST defaults to LOOPBACK — widen to 0.0.0.0 only deliberately (LAN /
+# mobile-device testing), and NEVER while a dev-auth bypass is active: an
+# AUTH_DISABLED-style mode that treats every request as admin is only safe
+# because it's loopback-contained. Don't export 0.0.0.0 unconditionally.
+env DATABASE_URL="$DATABASE_URL" PORT="$PORT" HOST="${HOST:-127.0.0.1}" \
   bash -c 'cd "$0"/<server-subdir> && bun run dev' "$root" &
 
-# Frontend — proxy to the actual backend port (important for non-default worktree ports).
-(cd "$root/<web-subdir>" && API_TARGET="http://localhost:${PORT}" VITE_PORT="$VITE_PORT" bun run dev) &
+# Repos with N backend processes per worktree (e.g. gRPC service + HTTP gateway):
+# start each the same way with its own picked port, threading the wiring env into
+# dependents — they all die via the same trap:
+#   GRPC_PORT="$(app_pick_grpc_port)"
+#   env DATABASE_URL="$DATABASE_URL" GRPC_PORT="$GRPC_PORT" \
+#     bash -c 'cd "$0"/<grpc-subdir> && bun run dev' "$root" &
+#   ...and pass ORCHESTRATOR_URL="http://localhost:${GRPC_PORT}" to consumers.
+
+# Frontend — proxy to the actual backend port (important for non-default worktree
+# ports). Convention: name the var VITE_API_TARGET (what real adopters use; the
+# vite config reads it to set server.proxy) rather than a bare API_TARGET. Proxy
+# /auth as well as /api when dev session cookies ride the proxy — a /api-only
+# proxy silently breaks login.
+(cd "$root/<web-subdir>" && VITE_API_TARGET="http://localhost:${PORT}" VITE_PORT="$VITE_PORT" bun run dev) &
 
 wait

--- a/skills/agent-dev-workflow/references/bin/setup
+++ b/skills/agent-dev-workflow/references/bin/setup
@@ -54,3 +54,12 @@ app_migrate "$url"
 echo "DATABASE_URL=${url}"
 echo "APP_DATABASE=${db}"
 echo "PORT=$(app_pick_port)"
+# Emit EVERY derived port (one per process kind) plus the wiring vars that
+# connect the processes, and the shared aux-service endpoints (SKILL.md
+# "Auxiliary services") — the orchestrator captures this one stdout block:
+#   grpc_port="$(app_pick_grpc_port)"
+#   echo "GRPC_PORT=${grpc_port}"
+#   echo "ORCHESTRATOR_URL=http://localhost:${grpc_port}"
+#   echo "VALIDATOR_URL=${VALIDATOR_URL:-http://localhost:9010}"
+# Apps that read discrete DB_* vars instead of DATABASE_URL: also emit both forms.
+#   app_db_env

--- a/skills/agent-dev-workflow/references/gotchas.md
+++ b/skills/agent-dev-workflow/references/gotchas.md
@@ -65,24 +65,40 @@ Two ways to choose it:
 On `postgres:18` the volume must mount at `/var/lib/postgresql`, **not**
 `/var/lib/postgresql/data` (the path used through 17). Mount the wrong one and the
 container's healthcheck never goes ready and `wait_for_postgres` times out after
-30s. If you pin `postgres:17-alpine` (the template default) use `…/data`; only
-change the mount if you deliberately move to 18.
+30s.
 
 **Pin the same major production runs.** Whatever major your prod DB is (Cloud SQL,
 RDS, …), pin that in `_common.sh` so `strip_cloudsql`'d snapshots restore without
-version-mismatch surprises. Across Jarvus repos this currently drifts (16 / 17 / 18
-all in use) — match *your* prod, and mind the data-dir caveat above when it's 18.
+version-mismatch surprises. That rule cuts both ways: when prod runs 18, you don't
+get to stay on the 17 template default to dodge the mount change. The `_common.sh`
+template carries the mount as `APP_PG_DATA_DIR` — for 18, change **both** lines
+together:
 
-## docker-compose can't do per-context isolation — remove it
+```bash
+APP_PG_IMAGE="postgres:18-alpine"
+APP_PG_DATA_DIR="/var/lib/postgresql"     # NOT /var/lib/postgresql/data
+```
 
-If the repo had a `docker-compose.yml` just to template a local Postgres, **delete
-it** once these scripts exist. Compose pins one fixed DB name and one fixed host
-port — exactly what defeats per-worktree databases and ports. It also breaks in
-this workflow specifically: compose ties operations to the directory it was first
-run from, so when an agent worktree is deleted while its compose containers keep
-running, you can't manage them without recreating that exact path. The `bin/`
-scripts manage a path-independent shared container by name instead. Keeping both
-invites "which Postgres am I talking to?" confusion — pick the scripts.
+Across Jarvus repos the major currently drifts (16 / 17 / 18 all in use) — match
+*your* prod. And remember container-reuse (below): switching majors on an existing
+container/volume needs a deliberate `docker rm` + volume removal.
+
+## docker-compose can't do per-context isolation — evict Postgres from it
+
+Compose pins one fixed DB name and one fixed host port — exactly what defeats
+per-worktree databases and ports. It also breaks in this workflow specifically:
+compose ties operations to the directory it was first run from, so when an agent
+worktree is deleted while its compose containers keep running, you can't manage
+them without recreating that exact path. So once these scripts exist, **remove the
+Postgres service (and the app itself) from compose** — the `bin/` scripts manage a
+path-independent shared container by name instead. Keeping a compose Postgres
+alongside the bin/ one invites "which Postgres am I talking to?" confusion.
+
+That's an eviction, not necessarily a deletion. Compose keeps exactly one job:
+the **once-per-machine auxiliary-services runner** (a validator container, a local
+OIDC IdP — see SKILL.md "Auxiliary services"). Those are shared across all
+worktrees, never replicated per worktree, so compose's one-fixed-port model is
+correct for them. If the file only templated Postgres, delete it outright.
 
 ## `cd` inside a piped/exec'd script
 

--- a/skills/agent-dev-workflow/references/migrations-and-seeds.md
+++ b/skills/agent-dev-workflow/references/migrations-and-seeds.md
@@ -6,7 +6,7 @@ is where you adapt.
 
 ## Migrations
 
-Set `app_migrate()` to however the project applies migrations. Two shapes seen
+Set `app_migrate()` to however the project applies migrations. Three shapes seen
 across real projects:
 
 - **A package script** (simplest — reuse what `package.json` already defines):
@@ -32,13 +32,51 @@ across real projects:
   }
   ```
 
+- **A self-migrating app** — the app runs its own programmatic migration runner
+  at boot: fresh-bootstrap when the DB is empty, baseline detection on an
+  existing schema, then additive incremental migrations. The division of labor
+  flips: **`bin/dev` needs no migrate step** (starting the app *is* migrating),
+  and `bin/setup` + the test preload call the app's own runner instead of
+  shelling out to a migration CLI. For `bin/setup` that means a thin entrypoint
+  into the runner:
+
+  ```bash
+  app_migrate() {
+    local url="$1"
+    echo "Running migrations..." >&2
+    (cd "$(app_server_dir)" && DATABASE_URL="$url" \
+      uv run python -c 'from app.db.migrations import run; run()') >&2
+  }
+  ```
+
+  Keep the `app_migrate` call in `setup`/`reset-db` anyway — it makes the DB
+  queryable via `bin/db` before first boot, and a skipped migrate is
+  self-healing here (the next app start covers it).
+
 The **test preload** migrates in-process instead of shelling out (it's already in
-JS and wants no Docker dependency) — typically drizzle-orm's programmatic
-`migrate(drizzle(sql), { migrationsFolder })`. Both read the same migrations
-folder; they're two callers of one migration set, not two migration systems.
+the app's language and wants no Docker dependency) — drizzle-orm's programmatic
+`migrate(drizzle(sql), { migrationsFolder })`, or for a self-migrating app,
+importing and awaiting the app's own runner. Both read the same migration set as
+`app_migrate`; they're two callers of one migration system, not two systems.
 
 Non-bun stacks: `alembic upgrade head` (Python), `rails db:migrate`,
 `migrate -path … up` (golang-migrate), etc. — same idea, swap the command.
+
+### The `/docker-entrypoint-initdb.d` mount — recognize it, then retire it
+
+A common pre-`bin/` idiom you'll meet during adoption: the compose file mounts
+the migrations directory into the Postgres container at
+`/docker-entrypoint-initdb.d`, so the official image applies the `.sql` files
+itself. Its trap: those scripts run **only on the first boot of an empty
+volume**. Add a migration later and every existing volume silently never sees
+it — the "migration system" stops migrating the moment anyone has data. It also
+couples schema application to container creation, which the shared-container
+pattern deliberately decouples.
+
+Retirement path: point `app_migrate` at the same migration files via a real
+runner (any of the three shapes above), drop the mount from the container
+definition, and let `bin/setup`/`bin/reset-db` own schema application. Existing
+volumes don't need recreating — the runner brings them forward.
 
 ## Seeds (optional) — three postures
 

--- a/skills/agent-dev-workflow/references/orchestrator-integration.md
+++ b/skills/agent-dev-workflow/references/orchestrator-integration.md
@@ -9,12 +9,22 @@ with zero manual config. These scripts provide exactly that contract.
 
 - **setup** → `bin/setup`. Idempotent: ensures the shared container, creates this
   worktree's DB (derived from its path), installs deps, migrates. It **prints
-  `KEY=VALUE` env lines to stdout** (`DATABASE_URL`, `APP_DATABASE`, `PORT`, and
-  `VITE_PORT` for fullstack) and all human status to **stderr** — so an
-  orchestrator can capture stdout and inject those vars into the run step.
-- **run** → `bin/dev` (or `bin/server`). Picks the same free port and derives the
+  `KEY=VALUE` env lines to stdout** and all human status to **stderr** — so an
+  orchestrator can capture stdout and inject those vars into the run step. The
+  stdout block must be **complete**: `DATABASE_URL` + `APP_DATABASE`, *every*
+  derived port (one per process kind — `PORT`, `GRPC_PORT`, `VITE_PORT`, …), the
+  inter-service wiring vars (`ORCHESTRATOR_URL=http://localhost:${GRPC_PORT}`),
+  and the shared aux-service endpoints (`VALIDATOR_URL=…` — see SKILL.md
+  "Auxiliary services"). Apps that read discrete `DB_*` vars instead of a URL:
+  emit both forms (`app_db_env`).
+- **run** → `bin/dev` (or `bin/server`). Picks the same free ports and derives the
   same DB, so it works whether or not the orchestrator threaded `setup`'s output
-  through. Uses `exec` for clean signal handling.
+  through. Uses `exec` for clean signal handling. Binds **loopback by default**
+  (`HOST=127.0.0.1`): an orchestrator that needs LAN exposure must opt in
+  explicitly — and must never widen a dev-auth-bypass instance (an
+  AUTH_DISABLED-style everyone-is-admin mode) beyond loopback. If the
+  orchestrator health-checks the service, `curl` works for HTTP ports but **not
+  gRPC** — probe those with a plain TCP connect.
 - **cleanup** → `bin/cleanup`. Drops this worktree's DB (refuses the canonical
   one without `--force`); stops the dev session if a fullstack `bin/dev` left a
   PID file. Leaves the shared container up for other worktrees.
@@ -37,5 +47,6 @@ needs no per-session config — just register the three scripts once.
 ## Override hooks
 
 Every derived value has an env override for when an orchestrator wants explicit
-control: `APP_DATABASE`, `APP_PG_PORT`, `PORT`, `VITE_PORT`. Honor these first in
+control: `APP_DATABASE`, `APP_PG_PORT`, `PORT`, `VITE_PORT`, plus one per extra
+process kind (`GRPC_PORT`, …) and `HOST` (default loopback). Honor these first in
 every script (the templates do).

--- a/skills/agent-dev-workflow/references/test-isolation.md
+++ b/skills/agent-dev-workflow/references/test-isolation.md
@@ -19,6 +19,13 @@ This reference has two halves: the **plumbing** — a dedicated, auto-migrated t
 preload = ["./test/setup.ts"]
 ```
 
+Mind existing `[test]` config: `bun test` globs **across nested packages**, so a
+monorepo's root `bunfig.toml` may already carry `[test] pathIgnorePatterns` to
+keep sub-package suites out of the root run. **Extend that existing `[test]`
+block** with the `preload` key — pasting the snippet as a second `[test]` block
+(or overwriting the file) clobbers the ignore patterns and suddenly pulls every
+nested package's tests into the run.
+
 `test/setup.ts` runs once before any test file. It must:
 
 1. Default `DATABASE_URL` to the test DB **with `??=`** — so an explicit env
@@ -60,6 +67,11 @@ Then delete the per-file `process.env.DATABASE_URL = …` lines from each test �
 the preload centralizes them. Keep any per-suite *override* (e.g. a suite that
 sets `MIN_SUPPORTED_BUILD=500` to exercise a code path) — just drop the shared DB/secret defaults.
 
+Apps that read discrete `DB_HOST`/`DB_PORT`/`DB_NAME`/`DB_USER`/`DB_PASSWORD`
+vars instead of a URL: `??=` each discrete var the same way — or better, teach
+the app to accept `DATABASE_URL` with a discrete-var fallback, so the preload,
+`bin/`, and CI all speak one URL.
+
 ## Why `??=` and not `=`
 
 `??=` only fills in a default when nothing was provided. CI sets `DATABASE_URL`
@@ -72,6 +84,21 @@ CI already points at a throwaway service-container DB via an explicit
 `DATABASE_URL` and runs its own migrate step. This whole pattern is a **local-dev**
 change — verify CI is green after adding the preload, but you should not need to
 edit the CI workflow.
+
+**Unless CI deliberately has no database.** Some repos run CI DB-less: live-DB
+suites self-skip (`describe.skipIf(...)`) and only pure suites gate merges. The
+preload as written breaks that CI — it unconditionally connects and migrates,
+and there's nothing to connect to. Two legitimate postures; pick one on purpose:
+
+- **Add a service container** (the `ci-quality-gates` default) — DB coverage on
+  every PR; the preload works unchanged.
+- **Skip when unreachable** — the preload probes Postgres with a
+  short-timeout connect; on failure it sets a flag the live-DB suites check
+  (feeding their `skipIf`) and returns instead of throwing. Keeps fork PRs and
+  minimal runners green at the cost of DB coverage in that lane.
+
+Don't leave it implicit — a preload that hard-fails in a deliberately DB-less CI
+looks like a flaky suite, not a design choice.
 
 ## Residual footgun to document, not over-engineer
 


### PR DESCRIPTION
Updates `skills/agent-dev-workflow/` (SKILL.md + references/) per the gap analysis from adopting the skill in **continuous-gtfs** — a two-backend (gRPC orchestrator + HTTP API) + Python-worker + React-UI monorepo — and codifies the maintainer's architectural decision on auxiliary services.

## The stance (core change)

What replicates per worktree is **the app + its database — nothing more**. Auxiliary services (a GTFS validator container, a local OIDC IdP) run **once per machine** and are shared across all worktree instances; per-worktree envs point at the shared endpoints (e.g. `VALIDATOR_URL` threaded through `bin/setup`'s stdout). Consequences for the compose guidance:

- **No aux services** → no docker-compose at all; `bin/` owns the shared Postgres container directly (unchanged prescription).
- **Aux services exist** → compose covers **only those**, fired up once per machine — never the per-worktree app or Postgres.
- `bin/` is **not** expanded to orchestrate aux containers; the boundary is documented instead: `bin/` = per-worktree identity, compose = machine-wide singletons.

New "Auxiliary services" section in SKILL.md; gotchas' compose section softened from "remove it" to "evict Postgres; keep compose as the once-per-machine aux-services runner"; build-order step updated to match.

## Smaller fixes (same adoption pass)

- **Multi-backend ports** — the port band claims one range per process kind; one picker per kind in `_common.sh`; `bin/setup` emits every derived port + inter-service wiring vars (`ORCHESTRATOR_URL`); gRPC ports get TCP readiness checks, not curl (SKILL.md, `_common.sh`, `setup`, `dev-fullstack`, orchestrator-integration.md)
- **Self-migrating apps** — third first-class migration shape: the app runs its own programmatic runner at boot (fresh-bootstrap / baseline / additive-incremental); `bin/dev` needs no migrate step; `bin/setup` + the test preload call the app's runner (migrations-and-seeds.md)
- **DATABASE_URL isn't universal** — new `app_db_env` helper emits discrete `DB_*` vars; guidance: emit both forms from `bin/`, or teach the app `DATABASE_URL` with a discrete-var fallback (bin templates, test-isolation.md, orchestrator-integration.md)
- **No-DB CI posture** — skip-when-unreachable documented as a legitimate preload posture alongside "add a service container" (SKILL.md CI seam, test-isolation.md §CI)
- **Don't force `HOST=0.0.0.0`** — `dev-fullstack` now defaults to loopback; an AUTH_DISABLED-style everyone-is-admin dev mode must never be widened beyond loopback (dev-fullstack, orchestrator-integration.md)
- **PG18 ready-variant** — the explicit 18 configuration is shipped, not just warned about: `postgres:18-alpine` + `APP_PG_DATA_DIR=/var/lib/postgresql` (gotchas.md, `_common.sh`)
- **initdb-mount idiom** — `/docker-entrypoint-initdb.d` named, its first-boot-of-the-volume-only trap, and its retirement path during bin/ adoption (migrations-and-seeds.md)
- **Nested bun packages** — the bunfig preload must extend an existing `[test]` block (`pathIgnorePatterns`), not clobber it (test-isolation.md)
- **Vite proxy naming** — `VITE_API_TARGET` convention (matching real adopters) over the bare `API_TARGET` placeholder; proxy `/auth` alongside `/api` when dev session cookies ride the proxy (dev-fullstack)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VZrUa8ajYuSGwbsnvTCkkH