### PR TITLE
docs(ci-quality-gates): reconcile with flagship reality; docs/codegen/private-dep/multi-package gaps

### DIFF
--- a/skills/ci-quality-gates/README.md
+++ b/skills/ci-quality-gates/README.md
@@ -26,7 +26,7 @@ credentialed checks (`tofu plan`, integration tests) are a separate later gate.
 ## What it gives the agent
 
 - a one-place **provisioning composite action** (asdf + cache + reshim) to call from every job,
-- copy-ready **GitHub Actions** templates (`lint`, `test`, `ui-checks`, `tf-validate`),
+- copy-ready **GitHub Actions** templates (`lint`, `test`, `ui-checks`, `tf-validate`, `docs`),
 - the **oxlint/oxfmt** configs (base + stricter React) and the **ruff** rule block,
 - the **TS script contract** and the one-time **adoption migration** recipe so an existing repo
   goes green on the gate's first run.

--- a/skills/ci-quality-gates/SKILL.md
+++ b/skills/ci-quality-gates/SKILL.md
@@ -20,7 +20,7 @@ re-deciding — or skipping it.
 ## Scope: what's in, what's out
 
 | In scope (gates a PR before merge) | Out of scope (hand off) |
-|---|---|
+| --- | --- |
 | asdf provisioning + tool caching | Release-PR automation → **`release-flow`** |
 | lint, format-check, type-check, test | Container build / image publish → per-stack build docs |
 | IaC `fmt` + `validate` (credential-free) | Deploy / `tofu apply` → **`sysadmin`** / deploy skill |
@@ -28,6 +28,15 @@ re-deciding — or skipping it.
 
 One-sentence charter: **how a repo gates a PR before it merges.** If credentials
 or a release tag are involved, it's a different skill.
+
+**Know the hole this scope leaves: Dockerfiles.** Image builds being
+out-of-scope means a Dockerfile break passes every PR gate and first fails
+*after* merge, on the push-triggered build workflow. Adopters should accept
+that consciously — the fix, when it has bitten, is a docker-build smoke job in
+the PR gate set (build, don't push; still credential-free), not moving
+publish/deploy here. Where image builds *are* gated is the per-stack build
+docs and deploy skills. (Frontend `vite build` is different — that one is
+in-scope and cheap; see `ui-checks.yml`.)
 
 ## Enforcement philosophy
 
@@ -68,14 +77,14 @@ into these rules rather than reinventing CI.
 ## The two reference deep-dives
 
 | File | Read when |
-|---|---|
+| --- | --- |
 | [provisioning.md](references/provisioning.md) | the CI harness — asdf + cache composite, lockfile-frozen installs, path filters, credential-free principle, private-dep git rewrite |
 | [tool-standards.md](references/tool-standards.md) | the linters/formatters — the TS script contract, oxc + ruff configs, the `typecheck` naming convention, the editor-feedback loop (no pre-commit), the one-time adoption migration |
 
 ## The gate set
 
 | Gate | TypeScript | Python | IaC |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | Lint | `oxlint` | `ruff check` | — |
 | Format | `oxfmt --check` | `ruff format --check` | `tofu fmt -check` |
 | Types | `tsc --noEmit` | `mypy` (optional) | `tofu validate -backend=false` |
@@ -114,6 +123,13 @@ Plus three rules that make CI reproducible and cheap (full rationale in
   `uv run --frozen …`. A PR can't pass against unrecorded dependency versions.
 - **Path-filtered triggers** — each workflow fires only on its domain (and on
   edits to itself).
+- **Leave `pull_request.branches` unrestricted** — filter PR triggers by
+  `paths`, never by base branch. In the develop→main Release-PR flow, the
+  release PR targets `main`; an unrestricted `pull_request` trigger re-runs the
+  full gate set on it alongside release-validate, re-gating exactly what's
+  about to ship. Adding `branches: [develop]` to `pull_request` silently
+  un-gates release PRs. (The `push` trigger *does* restrict to
+  `branches: [develop]` — that one's correct.)
 - **Credential-free** — lint/format/type-check/validate/hermetic-tests need no
   secrets, so they run on fork PRs and start instantly.
 
@@ -122,12 +138,13 @@ Plus three rules that make CI reproducible and cheap (full rationale in
 `references/templates/` — copy and adapt (each carries `# ADAPT:` markers):
 
 | Template | Drop at | Purpose |
-|---|---|---|
+| --- | --- | --- |
 | `github-actions/setup-asdf/action.yml` | `.github/actions/setup-asdf/action.yml` | the shared provisioning composite |
 | `github-actions/lint.yml` | `.github/workflows/lint.yml` | ruff + oxc/tsc lint gate (per-package matrix) |
 | `github-actions/test.yml` | `.github/workflows/test.yml` | pytest + bun test gate |
-| `github-actions/ui-checks.yml` | `.github/workflows/ui-checks.yml` | single-package frontend lint+fmt+types |
+| `github-actions/ui-checks.yml` | `.github/workflows/ui-checks.yml` | single-package frontend lint+fmt+types+test+build |
 | `github-actions/tf-validate.yml` | `.github/workflows/tf-validate.yml` | OpenTofu fmt + validate |
+| `github-actions/docs.yml` | `.github/workflows/docs.yml` | mkdocs strict build gates PRs; Pages deploy on push only |
 | `oxlintrc.base.json` | `.oxlintrc.json` (or root `.oxlintrc.base.json` in a monorepo) | TS lint config — correctness=error |
 | `oxlintrc.react.json` | `<ui>/.oxlintrc.json` | stricter React/UI lint config |
 | `ruff.pyproject.toml` | append to `pyproject.toml` | ruff rule set |

--- a/skills/ci-quality-gates/references/provisioning.md
+++ b/skills/ci-quality-gates/references/provisioning.md
@@ -146,8 +146,8 @@ private dep (and therefore the token) into a job that never imports the
 project. ruff doesn't need the project installed at all, so run it lean:
 
 ```bash
-uv run --frozen --no-install-project --only-group dev ruff check .
-uv run --frozen --no-install-project --only-group dev ruff format --check .
+uv run --frozen --only-group dev ruff check .
+uv run --frozen --only-group dev ruff format --check .
 ```
 
 That installs only the `dev` dependency group (where ruff lives), so lint stays

--- a/skills/ci-quality-gates/references/provisioning.md
+++ b/skills/ci-quality-gates/references/provisioning.md
@@ -42,11 +42,32 @@ So choose provisioning by what the repo pins:
   Targeted actions still read versions from `.tool-versions` where they can, so
   it stays the single source of truth.
 
+- **A subdirectory pins its own tool** — a repo can deliberately keep a tool
+  *out* of the root `.tool-versions` and pin it in a subdir's own
+  `.tool-versions` instead (asdf resolves the nearest file walking up). Seen in
+  a client deployment repo: the root file pins uv/python/opentofu for the
+  pipeline + IaC gates, while a self-contained UI package pins its own bun in
+  `<pkg>/.tool-versions`. The composite won't install that tool (it only reads
+  the root file), so the package's gate provisions it with a targeted action
+  pointed at the nested file:
+
+  ```yaml
+  - uses: oven-sh/setup-bun@v2
+    with:
+      bun-version-file: <pkg>/.tool-versions
+  ```
+
+  The nested file is still the single source of truth for that package — local
+  asdf and CI read the same file, just a different one than the root.
+
 ## The composite action (when every pinned tool has a plugin)
 
-The provisioning steps repeat in every job. continuous-gtfs currently inlines
-them ~6 times across `lint.yml` / `test.yml` / `ui-checks.yml`; that's the proven
-behavior but it rots. Consolidate into one local composite action and call it:
+The provisioning steps repeat in every job. Consolidate them into one local
+composite action and call it — this is the proven state, not an aspiration:
+the continuous-gtfs flagship calls `./.github/actions/setup-asdf` from every
+job across `lint.yml` / `test.yml` / `ui-checks.yml` / `docs.yml` (zero
+inlined copies), and its composite is byte-identical to the template here.
+Don't regress to inlining the block per job — that's how the copies rot apart.
 
 ```yaml
 steps:
@@ -69,6 +90,15 @@ Drop `templates/github-actions/setup-asdf/action.yml` at
 
 `checkout` must come first so the local `./.github/actions/setup-asdf` path
 exists before it's referenced.
+
+**Cache-key caveat for nested `.tool-versions`:** the composite's cache key is
+`hashFiles('.tool-versions')` — the **root** file only. If the repo also has
+per-package `.tool-versions` files (previous section) *and* the composite is
+what provisions those jobs, a bump to a nested file won't change the key, so
+CI restores a stale toolchain. Either provision those packages with targeted
+setup actions (the usual answer — then the composite key correctly covers only
+what the composite installs), or widen the key to include them:
+`hashFiles('.tool-versions', '**/.tool-versions')`.
 
 ## Reproducibility: lockfiles + frozen installs
 
@@ -108,6 +138,21 @@ The one exception: pulling a **private git dependency/module**. That needs a
 repo-scoped token, not cloud credentials — a `git config --global url.…insteadOf`
 rewrite (commented in `test.yml` / `tf-validate.yml`). It stays cheap and
 fork-safe-ish; just be aware forks won't have the secret.
+
+**Keep that exception out of the lint gate.** On a Python repo whose
+`pyproject.toml` carries a private git dependency, a plain
+`uv run --frozen ruff check` syncs the *whole* environment first — dragging the
+private dep (and therefore the token) into a job that never imports the
+project. ruff doesn't need the project installed at all, so run it lean:
+
+```bash
+uv run --frozen --no-install-project --only-group dev ruff check .
+uv run --frozen --no-install-project --only-group dev ruff format --check .
+```
+
+That installs only the `dev` dependency group (where ruff lives), so lint stays
+credential-free and fork-safe. The token rewrite is scoped to `test.yml` /
+`tf-validate.yml` — the gates that genuinely need the dependency resolved.
 
 ## What this deliberately is NOT
 

--- a/skills/ci-quality-gates/references/templates/github-actions/docs.yml
+++ b/skills/ci-quality-gates/references/templates/github-actions/docs.yml
@@ -1,0 +1,63 @@
+name: Docs
+
+# Docs gate + Pages deploy, one workflow, shared build job. The strict build
+# GATES pull requests — a broken link or a page missing from nav fails the PR
+# instead of failing after merge inside the deploy run. The Pages upload/deploy
+# only happens on push to develop (job-level `if`), so PRs get the gate without
+# the deploy or its permissions.
+on:
+  pull_request:
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - '.github/workflows/docs.yml'
+  push:
+    branches: [develop]
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - '.github/workflows/docs.yml'
+
+# pages/id-token are only exercised by the push-only deploy job; PR runs use
+# nothing beyond contents: read.
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Per-ref group: serializes develop deploys without letting a PR build cancel
+# an in-flight deploy (a bare `group: pages` would).
+concurrency:
+  group: pages-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-asdf   # provides uv/uvx; or astral-sh/setup-uv@v7 if the composite doesn't fit
+
+      # uvx pulls mkdocs + theme without a project-level dependency.
+      # ADAPT: one --with per plugin the site uses (e.g. --with mkdocs-mermaid-zoom).
+      - name: Build docs
+        run: uvx --with mkdocs-material mkdocs build --strict
+
+      # Only the push run feeds a deploy; skip the upload on PRs.
+      - name: Upload pages artifact
+        if: github.event_name == 'push'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    if: github.event_name == 'push'
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/skills/ci-quality-gates/references/templates/github-actions/ui-checks.yml
+++ b/skills/ci-quality-gates/references/templates/github-actions/ui-checks.yml
@@ -2,7 +2,14 @@ name: UI Checks
 
 # Single-package frontend (e.g. a Vite + React app under app/ or ui/). Use this
 # instead of the ts-lint matrix when the front end is one package you want gated
-# on its own path. Lint + format + type-check in one job.
+# on its own path. Lint + format + type-check + test + build in one job.
+#
+# Scope note: the Build step here is the FRONTEND COMPILE/BUILD gate — cheap,
+# credential-free, and it catches real breaks (`vite build` walks the full
+# asset graph, so a bad import of a CSS/image/route asset fails here even when
+# `tsc -b` is clean). That is in scope. CONTAINER image builds are not — a
+# Dockerfile is exercised by the push-triggered build workflow, which belongs
+# to the release/deploy skills (see the scope table in SKILL.md).
 on:
   pull_request:
     paths:
@@ -19,7 +26,7 @@ permissions:
 
 jobs:
   checks:
-    name: Lint, format, type-check
+    name: Lint, format, type-check, test, build
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -35,3 +42,11 @@ jobs:
         run: bun run format:check
       - name: Type check
         run: bun run typecheck
+      - name: Test
+        run: bun run test
+      # `vite build` resolves the full asset/import graph (CSS, images, route
+      # files) that `tsc -b` never sees — a broken asset import passes
+      # typecheck and fails only here. Delete only if the package truly has no
+      # build script.
+      - name: Build
+        run: bun run build

--- a/skills/ci-quality-gates/references/tool-standards.md
+++ b/skills/ci-quality-gates/references/tool-standards.md
@@ -112,7 +112,7 @@ not the linter's.
 - **If `pyproject.toml` carries a private git dependency**, don't let lint sync
   it: `uv run --frozen` installs the whole project env, which pulls the private
   dep and forces a token into a gate that never imports the code. Run ruff
-  lean instead — `uv run --frozen --no-install-project --only-group dev
+  lean instead — `uv run --frozen --only-group dev
   ruff check .` (and the `format --check` twin) — so lint stays credential-free
   and fork-safe. Full rationale in `provisioning.md` ("Credential-free by
   design").

--- a/skills/ci-quality-gates/references/tool-standards.md
+++ b/skills/ci-quality-gates/references/tool-standards.md
@@ -63,6 +63,17 @@ bun add -d oxlint oxfmt
     adjustment applies to the React config below when it lives in a subpackage —
     fix its `$schema` to match the package's depth.
 
+    **Third layout: multi-package repo *without* a workspace root.** Not every
+    multi-package repo is a bun workspace — the continuous-gtfs flagship has no
+    root `package.json` at all; each `services/*` package runs its own
+    `bun install` and carries its own lockfile. There oxlint is installed *per
+    package*, so each `.oxlintrc.json` keeps the single-package
+    `"$schema": "./node_modules/oxlint/configuration_schema.json"` (nothing is
+    hoisted to point up at), while `extends` still climbs to the shared root
+    config: `"extends": ["../../.oxlintrc.base.json"]`. Pick the `$schema` path
+    by **where oxlint's `node_modules` actually is**, not by whether the repo
+    "looks like" a monorepo.
+
     A server package that contains a UI subfolder ignores it so the UI is linted
     by its own stricter config: add `"ignorePatterns": ["ui"]`.
 - **React/UI packages** get a stricter config — `templates/oxlintrc.react.json`
@@ -98,6 +109,13 @@ not the linter's.
   generated files (protobuf, etc.) via `per-file-ignores`.
 - Add it with `uv add --dev ruff`. CI runs `uv run --frozen ruff check` and
   `uv run --frozen ruff format --check`.
+- **If `pyproject.toml` carries a private git dependency**, don't let lint sync
+  it: `uv run --frozen` installs the whole project env, which pulls the private
+  dep and forces a token into a gate that never imports the code. Run ruff
+  lean instead — `uv run --frozen --no-install-project --only-group dev
+  ruff check .` (and the `format --check` twin) — so lint stays credential-free
+  and fork-safe. Full rationale in `provisioning.md` ("Credential-free by
+  design").
 - **mypy is optional.** Data/infra repos that want strict typing add
   `uv add --dev mypy` and a `uv run mypy src/` step with `strict = true`. The
   flagship pipeline skips it; reach for it when the type surface is worth it.
@@ -111,7 +129,24 @@ root module. Format + config-validity only — never `tofu plan` in this gate
 ## Docs (optional)
 
 A docs site (mkdocs) gets a build gate: `mkdocs build --strict` so a broken link
-or missing nav entry fails the PR. Trigger on `docs/**` + `mkdocs.yml`.
+or missing nav entry fails the PR. Trigger on `docs/**` + `mkdocs.yml` + the
+workflow file itself.
+
+**The build gates PRs; the deploy stays push-only.** Docs repos usually already
+have a push-to-develop Pages deploy — and it's tempting to leave it at that, but
+then a broken link merges green and only fails *after* it's on develop, inside
+the deploy run. Split the two in **one workflow with a shared build job**: the
+strict build runs on both `pull_request` and `push`, while the Pages
+upload/deploy jobs carry `if: github.event_name == 'push'` so PRs get the gate
+without the deploy (and without needing the `pages`/`id-token` permissions on
+fork PRs). `templates/github-actions/docs.yml` is that shape.
+
+Invoke mkdocs through `uvx` so the theme/plugins ride along without a
+project-level dependency:
+`uvx --with mkdocs-material mkdocs build --strict` (add a `--with` per plugin
+the site uses). No lockfile governs `uvx` here — the docs toolchain floats,
+which is acceptable for a docs gate; pin `--with 'mkdocs-material==X.Y'` if a
+theme release ever breaks the build.
 
 ## Local feedback: the editor, never a git hook
 
@@ -167,3 +202,31 @@ source). When adopting a gate on such a repo, **rebuild and commit the artifact*
 after the format/fix commits (e.g. `bun run build:<tool>`) — or scope
 oxlint/oxfmt to exclude the generated source so the bundle never moves. The
 committed `.mjs` is `linguist-generated`, so the rebuild collapses in review.
+
+**Beyond adoption: make drift a standing CI gate.** If the repo doesn't already
+have a drift check, add one — a job (in the workflow owning that toolchain) that
+regenerates the committed artifact with the **pinned** toolchain and fails on
+any diff. The flagship's shape, for committed protobuf/gRPC bindings:
+
+```yaml
+- name: Regenerate bindings
+  run: >
+    uv run --frozen python -m grpc_tools.protoc
+    --proto_path=../proto --python_out=src --grpc_python_out=src
+    ../proto/<pkg>/<service>.proto
+- name: Re-apply formatter          # only if the committed files are formatted post-generation
+  run: uv run --frozen ruff format src/<pkg>/<service>_pb2.py src/<pkg>/<service>_pb2_grpc.py
+- name: Fail on drift
+  run: git diff --exit-code -- src/<pkg>/<service>_pb2.py src/<pkg>/<service>_pb2_grpc.py
+```
+
+Without this, a `.proto` edit that skips the regen ships a stale client
+silently — every other gate stays green. Trigger the workflow on the source
+paths (`proto/**`) as well as the artifact's package. Two prerequisites:
+
+- **The generator's version must be lockfile-pinned** (`grpcio-tools` in
+  `uv.lock`, invoked via `uv run --frozen`). A floating generator makes the
+  gate flap on toolchain drift — red on someone else's upgrade, not on a real
+  stale artifact.
+- **Regenerate exactly like a developer would** — including any post-generation
+  formatting pass — or the diff never comes back clean.


### PR DESCRIPTION
Verified review of the skill against its two source repos — the continuous-gtfs flagship and a client deployment repo — reconciling stale claims and closing gaps the sources have since proven out. Nine changes:

1. **Fix stale flagship claim** (provisioning.md): the flagship no longer inlines provisioning ~6 times — every job calls the `./.github/actions/setup-asdf` composite (byte-identical to the template). Composite-everywhere is now documented as the proven state.
2. **Docs gate template** (new `github-actions/docs.yml` + tool-standards.md + SKILL.md table): `mkdocs build --strict` gates pull requests; the Pages deploy jobs run only on push-to-develop via job-level `if: github.event_name == 'push'`, sharing one build job. Uses the `uvx --with mkdocs-material` invocation style.
3. **ui-checks reconciled with the flagship**: adds `test` + `build` steps (`vite build` catches asset-graph/import breaks `tsc -b` misses), with a scope note separating the in-scope frontend build gate from out-of-scope container image builds.
4. **Non-workspace multi-package TS layout** (tool-standards.md): no root `package.json`, per-package installs — `$schema` stays `./node_modules/oxlint/configuration_schema.json` per package while `extends` climbs to the shared root `.oxlintrc.base.json`.
5. **Private-git-dep Python lint escape** (provisioning.md + tool-standards.md): plain `uv run --frozen ruff check` syncs the whole env and drags the private dep + token into lint; prescribe `uv run --frozen --no-install-project --only-group dev ruff check .` so lint stays credential-free and fork-safe. Token exception stays scoped to test/tf-validate.
6. **Standing codegen-drift gate** (tool-standards.md): beyond adoption-time rebuilds — a CI job that regenerates the committed artifact with the lockfile-pinned toolchain (`uv run --frozen python -m grpc_tools.protoc …` for committed pb2 files) and `git diff --exit-code`s it; generator must be lockfile-pinned or the gate flaps.
7. **Nested/per-package `.tool-versions`** (provisioning.md): root file deliberately omits a tool a subdir pins; provision with a targeted setup action (`*-version-file: <subdir>/.tool-versions`), and note the composite's `hashFiles('.tool-versions')` cache key only covers the root file.
8. **Release-PR re-gating rule** (SKILL.md): leave `pull_request.branches` unrestricted (filter by `paths` only) so the full gate set re-runs on develop→main Release PRs alongside release-validate; restricting to develop silently un-gates release PRs.
9. **Dockerfile hole footnote** (SKILL.md scope): image builds being out-of-scope means a Dockerfile break passes every PR gate and first fails post-merge on the push-triggered build — adopters accept that consciously or add a build smoke; cross-referenced where builds are gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VZrUa8ajYuSGwbsnvTCkkH
