### PR TITLE
feat(agent-dev-workflow): attach-aware bin/dev supervisor + proof-based bin/gc worktree sweep

### DIFF
--- a/skills/agent-dev-workflow/README.md
+++ b/skills/agent-dev-workflow/README.md
@@ -10,6 +10,11 @@ A Postgres-backed project where you want any of:
 
 - multiple copies of the backend running concurrently on one machine (one per worktree),
 - the `setup` / `run` / `cleanup` contract that AI agent orchestrators (Conductor and similar) expect,
+- a fullstack `bin/dev` that runs as an **attach-aware per-worktree singleton** — a second invocation
+  reuses the healthy running session (`KEY=VALUE` endpoints on stdout, `status`/`stop`/`logs`
+  subcommands, on-disk `.dev/logs/`) instead of double-booting,
+- a `bin/gc` that **sweeps merged agent worktrees** — proof-based (ancestry / `git cherry` / merged
+  PR), stopping their dev sessions and dropping their derived databases along the way,
 - an end to tests clobbering local dev/demo data,
 - a replacement for a docker-compose-just-for-local-Postgres setup.
 

--- a/skills/agent-dev-workflow/SKILL.md
+++ b/skills/agent-dev-workflow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agent-dev-workflow
-description: Set up an agent-friendly local dev workflow — a bin/ task-runner (inspired by GitHub's scripts-to-rule-them-all) over a shared Postgres container that gives every git worktree its own isolated database and ports, plus a dedicated test database so tests never clobber dev data. Use this whenever a project needs worktree-isolated local development, when setting up for AI agent orchestrators (Conductor and similar) that spin up a worktree per session and register setup/run/cleanup commands, when multiple copies of a backend must run concurrently on one machine, when replacing a docker-compose-for-local-postgres setup, when deciding whether auxiliary dev services (a validator container, a local OIDC IdP) replicate per worktree or run shared, or when tests keep wiping local dev/demo data. Triggers on "bin/ scripts", "worktree isolation", "per-worktree database/port", "scripts to rule them all", "agent dev environment", "setup/run/cleanup scripts", "shared auxiliary services", or tests clobbering the dev database.
+description: Set up an agent-friendly local dev workflow — a bin/ task-runner (inspired by GitHub's scripts-to-rule-them-all) over a shared Postgres container that gives every git worktree its own isolated database and ports, plus a dedicated test database so tests never clobber dev data. Use this whenever a project needs worktree-isolated local development, when setting up for AI agent orchestrators (Conductor and similar) that spin up a worktree per session and register setup/run/cleanup commands, when multiple copies of a backend must run concurrently on one machine, when replacing a docker-compose-for-local-postgres setup, when deciding whether auxiliary dev services (a validator container, a local OIDC IdP) replicate per worktree or run shared, when merged agent worktrees pile up and need sweeping, or when tests keep wiping local dev/demo data. Triggers on "bin/ scripts", "worktree isolation", "per-worktree database/port", "scripts to rule them all", "agent dev environment", "setup/run/cleanup scripts", "shared auxiliary services", "sweep merged worktrees", or tests clobbering the dev database.
 ---
 
 # Agent-friendly dev workflow (bin/ + worktree isolation)
@@ -53,13 +53,24 @@ know which parts you copy verbatim and which you adapt.
 
 **Invariant** (copy from `references/bin/`, just swap the `app`/`APP_` prefix):
 
-- worktree-aware DB naming (`app_db_name`, `is_main_worktree`, `app_hash`)
+- worktree-aware DB naming (`app_db_name`, `app_db_name_for_root`,
+  `is_main_worktree`, `app_hash`)
 - shared-container management (`ensure_postgres`, `wait_for_postgres`, `app_psql`)
 - DB create/recreate helpers; the `setup`/`reset-db`/`db`/`cleanup`/`test` scripts
   (keep these names — e.g. `db`, not `query` — so the muscle memory transfers across repos)
 - port picking (`port_in_use`, `find_available_port`, `app_pick_port`) — **including
   the macOS `lsof`/`ss` split; do not "simplify" it away** (see gotchas)
 - stdout=env / stderr=status discipline
+- the dev-session **state machine** (fullstack variant): the atomic noclobber
+  claim of `.dev/state.env` with `PHASE=booting` → `PHASE=running` only after
+  ports listen, snapshot-coherent reads, the ownership-checked EXIT/INT/TERM
+  trap, per-child process groups via `set -m` (never `kill 0`), and
+  `app_dev_stop`
+- **pid + start-time identity** (`app_pid_lstart`, `app_pid_is`) consulted
+  before every kill and every health verdict (see gotchas — pid recycling)
+- the `bin/gc` proof structure: mandatory gates + at least one containment
+  proof, the long-lived-branch denylist, the canonical-DB guard, and the fd-3
+  record stream (see gotchas — stdin-slurping loops)
 
 **Project-specific** (the knobs you set):
 
@@ -73,8 +84,11 @@ know which parts you copy verbatim and which you adapt.
 - the Postgres **major** — pin the same one production runs (`references/snapshots.md`)
 - `app_server_dir` — repo root (single package) vs a subdir (monorepo)
 - `app_migrate` — how migrations run → **`references/migrations-and-seeds.md`**
-- single-service `dev` (frontend runs separately) vs fullstack `dev` (starts both,
+- single-service `dev` (frontend runs separately) vs fullstack `dev` (an
+  attach-aware per-worktree singleton that starts both, supervises both, and
   kills both) → use `references/bin/dev` or `references/bin/dev-fullstack`
+- `bin/gc`'s integration branch — `APP_GC_BASE_REF` defaults to `origin/main`;
+  set `origin/develop` in repos that integrate on develop
 - the **seed posture** — synthetic SQL, snapshot-as-seed, or empty + per-suite
   fixtures (`references/migrations-and-seeds.md`), and whether it has prod snapshots
   at all (`references/snapshots.md`)
@@ -107,6 +121,24 @@ alongside the per-worktree values (e.g. `VALIDATOR_URL=http://localhost:9010`,
 overridable via env like everything else), so one stdout capture threads into the
 run step and every worktree converges on the same shared services.
 
+## Worktree lifecycle: create under `.claude/worktrees/`, sweep with `bin/gc`
+
+Agent worktrees should live under the repo's **`.claude/worktrees/`** directory
+(gitignore `**/.claude/worktrees/` so nested checkouts never show as untracked
+files). That location is what makes the end of the lifecycle automatic: a
+worktree is alive while its PR is in review and becomes garbage the moment it
+merges — but merges happen on the reviewer's schedule, with no local session
+listening. `bin/gc` closes that gap with a lazy, state-based sweep: it
+enumerates linked worktrees under any `*/.claude/worktrees/` path and removes
+only the ones it can **prove** merged (ancestry, `git cherry` patch
+containment, or a merged PR via `gh` — plus mandatory gates: clean, unlocked,
+not the main/current worktree, not a long-lived branch), stopping any recorded
+`bin/dev` session and dropping the derived database along the way. Everything
+unproven is skipped with a one-line reason; a `--nudge` mode is cheap enough to
+run from a SessionStart hook. Worktrees created *outside* `.claude/worktrees/`
+escape the sweep entirely — that's the trade you make by putting them
+elsewhere.
+
 ## Build order
 
 1. **Read the relevant references first** (below) — they encode hard-won bugs.
@@ -117,7 +149,11 @@ run step and every worktree converges on the same shared services.
    cleanly (`references/snapshots.md`).
 3. Set `app_server_dir` and `app_migrate` for this project
    (`references/migrations-and-seeds.md`).
-4. Choose the `dev` variant (single-service vs `dev-fullstack`).
+4. Choose the `dev` variant (single-service vs `dev-fullstack`). The fullstack
+   variant carries the whole session protocol (singleton claim, attach,
+   status/stop/logs, supervision) — copy its mechanics verbatim and adapt only
+   the two child-launch blocks. Copy `bin/gc` alongside it and set
+   `APP_GC_BASE_REF` if the repo integrates on a branch other than `main`.
 5. Wire **test isolation** — the preload that points tests at `app_test`
    (`references/test-isolation.md`). Do this when (or before) the project grows a
    DB-backed test suite: it's the step that stops tests wiping dev data. It's a clean
@@ -129,9 +165,12 @@ run step and every worktree converges on the same shared services.
    services" and gotchas). Update `.env.example` + the project's agent docs
    (CLAUDE.md or equivalent) to point at `bin/`.
 7. **Verify** end to end (don't assume): `bin/setup` on a clean checkout; the
-   sentinel-row test from `test-isolation.md`; `bin/dev` twice concurrently lands on
-   two different ports; `bin/cleanup` in a throwaway worktree leaves the main DB
-   intact. `bash -n` every script.
+   sentinel-row test from `test-isolation.md`; `bin/dev` in two *worktrees* lands on
+   two different ports; `bin/dev` twice in the *same* worktree → the second
+   attaches (exit 0, `KEY=VALUE` block) instead of double-booting; kill one
+   child process → the whole stack exits loudly (no half-dead session);
+   `bin/gc --dry-run` reports sane verdicts; `bin/cleanup` in a throwaway
+   worktree leaves the main DB intact. `bash -n` every script.
 
 ## Reference files
 

--- a/skills/agent-dev-workflow/references/bin/_common.sh
+++ b/skills/agent-dev-workflow/references/bin/_common.sh
@@ -56,16 +56,27 @@ app_hash() {
   fi
 }
 
+# Derived DB name for an ARBITRARY worktree root of this repo — bin/gc needs
+# it for worktrees other than the current one. Main worktree → the canonical
+# name; any other → app_<hash-of-path>. APP_DATABASE is deliberately NOT
+# consulted here: that override belongs to the *current* context only
+# (app_db_name below).
+app_db_name_for_root() {
+  local root="$1" main_worktree
+  main_worktree="$(git -C "$root" worktree list --porcelain | head -1 | sed 's/^worktree //')"
+  if [ "$root" = "$main_worktree" ]; then
+    echo "app"
+  else
+    echo "app_$(app_hash "$root")"
+  fi
+}
+
 app_db_name() {
   if [ -n "${APP_DATABASE:-}" ]; then
     echo "$APP_DATABASE"
     return
   fi
-  if is_main_worktree; then
-    echo "app"
-  else
-    echo "app_$(app_hash "$(app_root)")"
-  fi
+  app_db_name_for_root "$(app_root)"
 }
 
 app_database_url() {
@@ -188,6 +199,14 @@ app_pick_port() {
   find_available_port 4001 4099
 }
 
+# The frontend (Vite) port — used by the fullstack dev variant; harmless to
+# keep in single-service repos. Override with VITE_PORT.
+app_pick_vite_port() {
+  if [ -n "${VITE_PORT:-}" ]; then echo "$VITE_PORT"; return; fi
+  if ! port_in_use 4100; then echo "4100"; return; fi
+  find_available_port 4101 4199
+}
+
 # Multi-process backends: a worktree may run SEVERAL processes (HTTP API + gRPC
 # service + Vite, …). Add one picker PER PROCESS KIND, each with a DISJOINT range
 # inside the project's band (e.g. HTTP 4000-4049, gRPC 4050-4099, Vite 4100-4199 —
@@ -200,3 +219,156 @@ app_pick_port() {
 #   if ! port_in_use 4050; then echo "4050"; return; fi
 #   find_available_port 4051 4099
 # }
+
+# ── Dev session state (fullstack bin/dev singleton) ─────────────────────────
+# The fullstack bin/dev runs as a per-worktree SINGLETON. A running session
+# records itself in .dev/state.env (supervisor PID, child PIDs, chosen ports,
+# DATABASE_URL) and writes each service's output to .dev/logs/<service>.log.
+# These helpers are shared by bin/dev (attach/status/stop), bin/cleanup, and
+# bin/gc. Single-service repos (the plain `dev` template, which just execs)
+# don't use them — harmless to keep either way.
+#
+# The helpers assume the fullstack template's two children (SERVER + WEB) and
+# two ports (PORT + VITE_PORT). A stack with more processes extends BOTH key
+# lists in app_dev_session_healthy and the sweep list in app_dev_stop — one
+# entry per recorded child.
+
+app_dev_state_dir() { echo "$(app_root)/.dev"; }
+app_dev_state_file() { echo "$(app_dev_state_dir)/state.env"; }
+app_dev_log_dir() { echo "$(app_dev_state_dir)/logs"; }
+
+# ── PID identity ─────────────────────────────────────────────────────────────
+# A bare `kill -0 $pid` proves only that SOME process has that pid. state.env
+# survives a SIGKILLed supervisor and a reboot, and the OS recycles pids —
+# so every recorded pid is stored WITH its start time, and both the health
+# check and the stop path refuse to treat (or kill!) a recycled pid as ours.
+
+# Start time of a live process; empty when the pid is gone.
+app_pid_lstart() {
+  { ps -o lstart= -p "$1" 2>/dev/null || true; } | sed 's/^ *//;s/ *$//'
+}
+
+# True when $1 is alive AND is the exact process recorded as ($1, $2).
+# An empty recorded start time (state written by an older bin/dev) falls
+# back to plain liveness so in-flight sessions stay stoppable across the
+# upgrade.
+app_pid_is() {
+  local pid="$1" lstart="$2"
+  [ -n "$pid" ] || return 1
+  if [ -z "$lstart" ]; then
+    kill -0 "$pid" 2>/dev/null
+    return
+  fi
+  [ "$(app_pid_lstart "$pid")" = "$lstart" ]
+}
+
+# ── State reads ──────────────────────────────────────────────────────────────
+# Deliberately not `source`d: sourcing would clobber caller-provided env
+# overrides (PORT, VITE_PORT, ...) that the port pickers honor. The file can
+# vanish between any two reads (a dying supervisor's trap removes it), so
+# callers that need a COHERENT view take one app_dev_snapshot and read every
+# key from it — never a healthy-check against one read and an emit from
+# another.
+app_dev_snapshot() {
+  cat "$(app_dev_state_file)" 2>/dev/null || true
+}
+
+app_snap_get() {
+  printf '%s\n' "$1" | sed -n "s/^$2=//p" | head -1
+}
+
+# One-off single-key read (no coherence needed). Empty when file is missing.
+app_dev_state_get() {
+  app_snap_get "$(app_dev_snapshot)" "$1"
+}
+
+# Healthy = the boot finished (PHASE=running), the supervisor and both
+# services are alive AND are the exact recorded processes (pid + start time),
+# and both ports are listening. Anything less is a half-dead stack that
+# should be torn down, not attached to — a dead backend behind a live
+# frontend port serves nothing but proxy errors, and a foreign listener on
+# our recorded port is someone else's stack, not ours.
+# Takes an optional snapshot; snapshots itself when not given one.
+app_dev_session_healthy() {
+  local snap="${1:-$(app_dev_snapshot)}"
+  local key port
+  [ -n "$snap" ] || return 1
+  [ "$(app_snap_get "$snap" PHASE)" = "running" ] || return 1
+  for key in DEV SERVER WEB; do
+    app_pid_is "$(app_snap_get "$snap" "${key}_PID")" \
+      "$(app_snap_get "$snap" "${key}_PID_LSTART")" || return 1
+  done
+  for key in PORT VITE_PORT; do
+    port="$(app_snap_get "$snap" "$key")"
+    [ -n "$port" ] || return 1
+    port_in_use "$port" || return 1
+  done
+}
+
+# Booting = state.env claimed (PHASE=booting) by a supervisor that is still
+# alive. Distinct from unhealthy: a boot in progress should be WAITED ON,
+# never torn down — the pre-state window (postgres ensure, migrate, seed) can
+# run 10+ seconds and would otherwise be indistinguishable from a half-dead
+# session.
+app_dev_session_booting() {
+  local snap="${1:-$(app_dev_snapshot)}"
+  [ -n "$snap" ] || return 1
+  [ "$(app_snap_get "$snap" PHASE)" = "booting" ] || return 1
+  app_pid_is "$(app_snap_get "$snap" DEV_PID)" "$(app_snap_get "$snap" DEV_PID_LSTART)"
+}
+
+# Stop the recorded session: TERM the supervisor (its signal-aware EXIT trap
+# kills each child's process group), wait briefly, then sweep anything that
+# outlived it (e.g. a SIGKILLed supervisor): service + log-streamer process
+# groups. Every kill is identity-checked — a recycled pid is never signalled.
+# Also stops legacy .dev.pid-only sessions from the pre-singleton fullstack
+# template — those recorded no ports, so they can't be attached to. Always
+# returns 0; silent when nothing is running.
+app_dev_stop() {
+  local snap state pid lstart child key i
+  state="$(app_dev_state_file)"
+  # Snapshot everything up front: the supervisor's own EXIT trap removes
+  # state.env, so it can vanish the moment the kill below lands.
+  snap="$(app_dev_snapshot)"
+  if [ -n "$snap" ]; then
+    pid="$(app_snap_get "$snap" DEV_PID)"
+    lstart="$(app_snap_get "$snap" DEV_PID_LSTART)"
+    if app_pid_is "$pid" "$lstart"; then
+      echo "Stopping dev session (PID ${pid})..." >&2
+      kill "$pid" 2>/dev/null || true
+      for i in $(seq 1 50); do
+        app_pid_is "$pid" "$lstart" || break
+        sleep 0.2
+      done
+    fi
+    # Sweep survivors by process GROUP (bin/dev runs under `set -m`, so each
+    # child leads its own group and the group kill takes service grandchildren
+    # — bun run → vite — down too); plain pid as fallback for pre-set -m state.
+    for key in SERVER WEB TAIL; do
+      child="$(app_snap_get "$snap" "${key}_PID")"
+      if app_pid_is "$child" "$(app_snap_get "$snap" "${key}_PID_LSTART")"; then
+        kill -- -"$child" 2>/dev/null || kill "$child" 2>/dev/null || true
+      fi
+    done
+    rm -f "$state"
+  fi
+  local legacy
+  legacy="$(app_root)/.dev.pid"
+  if [ -f "$legacy" ]; then
+    pid="$(cat "$legacy" 2>/dev/null || true)"
+    if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+      echo "Stopping legacy dev session (PID ${pid})..." >&2
+      # The legacy supervisor traps only EXIT — a bare TERM kills it without
+      # its `kill 0` trap ever running, orphaning its children. When it
+      # leads its own process group (interactive launches), kill the whole
+      # group; only then is -$pid guaranteed to be ITS group and nobody else's.
+      if [ "$(ps -o pgid= -p "$pid" 2>/dev/null | tr -d ' ')" = "$pid" ]; then
+        kill -- -"$pid" 2>/dev/null || true
+      else
+        kill "$pid" 2>/dev/null || true
+      fi
+    fi
+    rm -f "$legacy"
+  fi
+  return 0
+}

--- a/skills/agent-dev-workflow/references/bin/cleanup
+++ b/skills/agent-dev-workflow/references/bin/cleanup
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Drop this worktree's database (leaves the shared container running for others).
-# Refuses to drop the canonical main-worktree DB unless forced.
+# Refuses to drop the canonical main-worktree DB unless forced. Also stops a
+# `bin/dev` session left running in this worktree.
 #
 # Usage:
 #   bin/cleanup            # drop this worktree's derived DB
@@ -11,19 +12,10 @@
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/_common.sh"
 
-root="$(app_root)"
-
-# If a fullstack bin/dev wrote a PID file, stop that session's process group first.
-# (Single-service setups can omit this block.)
-pidfile="$root/.dev.pid"
-if [ -f "$pidfile" ]; then
-  dev_pid="$(cat "$pidfile")"
-  if kill -0 "$dev_pid" 2>/dev/null; then
-    echo "Stopping dev session (PID $dev_pid)..." >&2
-    kill "$dev_pid" 2>/dev/null || true
-  fi
-  rm -f "$pidfile"
-fi
+# Stop any bin/dev session recorded for this worktree first (state.env
+# sessions and legacy .dev.pid ones alike). Single-service setups whose
+# bin/dev just execs in the foreground can omit this line.
+app_dev_stop
 
 db="$(app_db_name)"
 if [ "$db" = "app" ] && [ "${1:-}" != "--force" ]; then

--- a/skills/agent-dev-workflow/references/bin/dev-fullstack
+++ b/skills/agent-dev-workflow/references/bin/dev-fullstack
@@ -1,54 +1,373 @@
 #!/usr/bin/env bash
-# FULLSTACK variant: start backend + frontend together, kill both on exit.
-# Save as `bin/dev` in a repo where one command should run the whole stack
-# (e.g. Fastify + Vite). Picks a free port for each so concurrent worktrees
-# don't collide. Requires app_pick_vite_port() in _common.sh (see below).
+# FULLSTACK variant: run the dev stack (backend + frontend) as a per-worktree
+# SINGLETON session with on-disk logs and one-dies-all-die supervision. Save as
+# `bin/dev` in a repo where one command should run the whole stack (e.g.
+# Fastify + Vite). Picks a free port for each service so concurrent worktrees
+# don't collide (see bin/_common.sh's port-band claim). Protocol ported from
+# the open-source continuous-gtfs repo's bin/dev (its PR #290) — copy the
+# mechanics verbatim, adapt only the service list.
 #
-# Env overrides: DATABASE_URL, PORT, VITE_PORT, HOST, APP_DATABASE, APP_PG_PORT.
+#   bin/dev [--restart]
+#       Start the stack — or, if a healthy session is already running for
+#       this worktree, report its endpoints and exit 0 instead of starting a
+#       second one. A session still BOOTING (another bin/dev's pre-flight:
+#       postgres ensure, migrate) is waited on and then attached, never torn
+#       down. Attaching refuses (exit 2) when the running session doesn't
+#       match what was asked for — explicit DATABASE_URL/PORT/VITE_PORT
+#       overrides the session wasn't started with. A stale or half-dead
+#       session (any child gone, recycled pids) is torn down and replaced.
+#       --restart bounces whatever is there.
+#   bin/dev status
+#       Health-checked KEY=VALUE contract on stdout.
+#       Exit: 0 running / 1 stopped / 2 unhealthy / 3 starting.
+#   bin/dev stop
+#       Stop the recorded session (from any terminal).
+#   bin/dev logs [server|web]
+#       Follow the session logs (both interleaved when no service given).
+#
+# Session state lives in .dev/ (gitignore it): state.env records the
+# supervisor + child PIDs and the chosen ports; logs/<service>.log holds each
+# service's full output — fresh per session, kept after exit for
+# post-mortems. If any child exits, the whole stack tears down loudly — never
+# a half-dead session serving proxy errors from still-bound ports.
+#
+# Env overrides: DATABASE_URL, PORT, VITE_PORT, HOST, APP_DATABASE,
+# APP_PG_PORT, APP_DEV_LOG_CAP_BYTES.
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/_common.sh"
 
 root="$(app_root)"
 
+# KEY=VALUE contract for the recorded session (stdout — human text goes to
+# stderr, same split as bin/setup, so orchestrators can capture just these).
+# Reads from one snapshot ($1) — never the live file, which a dying
+# supervisor's trap can remove between the health check and these reads,
+# yielding STATUS=running with empty values.
+emit_session() {
+  local snap="$1" key
+  for key in DEV_PID DATABASE_URL PORT VITE_PORT; do
+    echo "${key}=$(app_snap_get "$snap" "$key")"
+  done
+  echo "LOG_DIR=$(app_dev_log_dir)"
+}
+
+# ── Subcommands ────────────────────────────────────────────────────────────
+case "${1:-}" in
+  status)
+    snap="$(app_dev_snapshot)"
+    if app_dev_session_healthy "$snap"; then
+      echo "STATUS=running"
+      emit_session "$snap"
+      echo "Dev session healthy (PID $(app_snap_get "$snap" DEV_PID)); logs: $(app_dev_log_dir)/" >&2
+      exit 0
+    fi
+    if app_dev_session_booting "$snap"; then
+      echo "STATUS=starting"
+      echo "DEV_PID=$(app_snap_get "$snap" DEV_PID)"
+      echo "LOG_DIR=$(app_dev_log_dir)"
+      echo "Dev session is starting (PID $(app_snap_get "$snap" DEV_PID)) — re-check shortly, or run 'bin/dev' to wait for it and attach." >&2
+      exit 3
+    fi
+    if [ -n "$snap" ] || [ -f "$root/.dev.pid" ]; then
+      echo "STATUS=unhealthy"
+      echo "Recorded session is not fully up — 'bin/dev' (or --restart) will replace it; 'bin/dev stop' clears it." >&2
+      exit 2
+    fi
+    echo "STATUS=stopped"
+    echo "No dev session running in this worktree." >&2
+    exit 1
+    ;;
+  stop)
+    app_dev_stop
+    exit 0
+    ;;
+  logs)
+    log_dir="$(app_dev_log_dir)"
+    svc="${2:-}"
+    if [ -n "$svc" ]; then
+      if [ ! -f "$log_dir/$svc.log" ]; then
+        echo "bin/dev logs: no log for '$svc' (expected: server, web)" >&2
+        exit 2
+      fi
+      exec tail -n 100 -F "$log_dir/$svc.log"
+    fi
+    if [ ! -d "$log_dir" ]; then
+      echo "bin/dev logs: no session logs yet — start one with bin/dev" >&2
+      exit 2
+    fi
+    exec tail -n 30 -F "$log_dir/server.log" "$log_dir/web.log"
+    ;;
+esac
+
+# ── Args (start mode) ──────────────────────────────────────────────────────
+RESTART=0
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --restart) RESTART=1; shift ;;
+    *) echo "bin/dev: unknown argument '$1' (subcommands: status, stop, logs)" >&2; exit 2 ;;
+  esac
+done
+
+# Explicit caller overrides, captured BEFORE the pickers fill defaults — the
+# attach path must refuse a session that wasn't started with them, instead of
+# exiting 0 with settings the caller didn't ask for.
+req_DATABASE_URL="${DATABASE_URL:-}"
+req_PORT="${PORT:-}"
+req_VITE_PORT="${VITE_PORT:-}"
+
+# ── Singleton check ────────────────────────────────────────────────────────
+# One session per worktree. A healthy running session (no --restart) is
+# reported and reused — a second terminal or a coding agent should attach to
+# it (read .dev/logs/, hit the recorded ports), not race it. A session still
+# booting is waited on, then attached. Anything less — half-dead stack, stale
+# state, legacy pidfile — is torn down before starting fresh.
+if [ "$RESTART" = 0 ]; then
+  snap="$(app_dev_snapshot)"
+  if app_dev_session_booting "$snap"; then
+    echo "A dev session is already starting here (PID $(app_snap_get "$snap" DEV_PID)) — waiting to attach..." >&2
+    for i in $(seq 1 120); do
+      sleep 1
+      snap="$(app_dev_snapshot)"
+      app_dev_session_booting "$snap" || break
+    done
+    if app_dev_session_booting "$snap"; then
+      echo "bin/dev: session PID $(app_snap_get "$snap" DEV_PID) has been booting for over 2 minutes — check $(app_dev_log_dir)/, or replace it with 'bin/dev --restart'." >&2
+      exit 2
+    fi
+  fi
+  if app_dev_session_healthy "$snap"; then
+    # Never silently attach across an explicit env-override mismatch: a
+    # session on other settings is not the session that was asked for.
+    mismatch=0
+    for key in DATABASE_URL PORT VITE_PORT; do
+      eval "requested=\"\$req_${key}\""
+      recorded="$(app_snap_get "$snap" "$key")"
+      if [ -n "$requested" ] && [ "$requested" != "$recorded" ]; then
+        [ "$mismatch" = 0 ] && echo "bin/dev: a healthy session is already running with different settings" >&2
+        echo "  ${key}: running ${recorded:-<unset>}, requested ${requested}" >&2
+        mismatch=1
+      fi
+    done
+    if [ "$mismatch" = 1 ]; then
+      echo "Replace it with: bin/dev --restart (same env), or unset the overrides to attach." >&2
+      exit 2
+    fi
+    echo "Dev session already running for this worktree (PID $(app_snap_get "$snap" DEV_PID)) — reusing it." >&2
+    echo "Logs: $(app_dev_log_dir)/ · follow with 'bin/dev logs' · bounce with 'bin/dev --restart'" >&2
+    echo "STATUS=running"
+    emit_session "$snap"
+    exit 0
+  fi
+fi
+if [ -n "$(app_dev_snapshot)" ] || [ -f "$root/.dev.pid" ]; then
+  if [ "$RESTART" = 0 ]; then
+    echo "Previous dev session is stale or half-dead — cleaning it up before starting." >&2
+  fi
+  app_dev_stop
+fi
+
+# ── Claim the singleton ────────────────────────────────────────────────────
+# Atomic exclusive create (noclobber) of state.env, BEFORE the slow pre-boot
+# work — otherwise two concurrent bin/devs both pass the checks above during
+# the pre-state window and boot duplicate stacks. PHASE stays "booting" until
+# the services are up and the full state is written; status/attach treat that
+# phase as wait-don't-touch.
+mkdir -p "$(app_dev_state_dir)"
+state_file="$(app_dev_state_file)"
+if ! (set -C; {
+  echo "PHASE=booting"
+  echo "DEV_PID=$$"
+  echo "DEV_PID_LSTART=$(app_pid_lstart $$)"
+} >"$state_file") 2>/dev/null; then
+  echo "bin/dev: lost the singleton race — another bin/dev claimed this worktree just now. Re-run bin/dev to wait for it and attach." >&2
+  exit 2
+fi
+
+# From claim to exit, this session owns cleanup. Installed before the slow
+# pre-boot work so a failed/interrupted boot releases the claim. The INT/TERM
+# traps convert those signals into a normal exit so the EXIT trap actually
+# runs — an untrapped fatal signal would skip it (exactly how 'bin/dev stop'
+# and bin/cleanup would otherwise leave the claim and half-dead stacks
+# behind). Logs are deliberately kept.
+cleanup() {
+  # Ownership check: a slow-dying replaced supervisor must not delete the
+  # record of the session that took over (which would leave the new stack
+  # running untracked — unstoppable by bin/dev stop / bin/cleanup).
+  if [ "$(app_dev_state_get DEV_PID)" = "$$" ]; then
+    rm -f "$state_file"
+  fi
+  # Kill each child's own process group (see `set -m` below) — deliberately
+  # NOT `kill 0`: the caller of 'bin/dev stop'/bin/cleanup shares this
+  # script's group when both were launched from the same non-interactive
+  # shell, and kill 0 would take the caller down mid-cleanup.
+  local p
+  for p in "${server_pid:-}" "${web_pid:-}" "${tail_pid:-}"; do
+    if [ -n "$p" ]; then
+      kill -- -"$p" 2>/dev/null || kill "$p" 2>/dev/null || true
+    fi
+  done
+  return 0
+}
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
 if [ -z "${DATABASE_URL:-}" ]; then
   ensure_postgres
+  # Ensure the database exists even when bin/setup hasn't run in this
+  # worktree — ensure-then-boot makes bin/dev standalone rather than
+  # crashing on a missing database.
+  app_ensure_db "$(app_db_name)"
   DATABASE_URL="$(app_database_url)"
 fi
 
 PORT="$(app_pick_port)"
-VITE_PORT="$(app_pick_vite_port)"   # add this picker to _common.sh (range e.g. 4100-4199)
+VITE_PORT="$(app_pick_vite_port)"
 
-echo "Frontend: http://localhost:${VITE_PORT}" >&2
-echo "Backend:  http://localhost:${PORT}" >&2
+# If the app does NOT run migrations itself on boot, run them here — the
+# singleton is already claimed (PHASE=booting), so a concurrent bin/dev
+# waits on this instead of racing it:
+# app_migrate "$DATABASE_URL"
 
-# PID file so bin/cleanup can stop this session's whole process group.
-pidfile="$root/.dev.pid"
-echo $$ > "$pidfile"
+log_dir="$(app_dev_log_dir)"
+mkdir -p "$log_dir"
+: >"$log_dir/server.log"
+: >"$log_dir/web.log"
 
-# kill 0 signals the whole process group → all children die when this script exits.
-trap 'rm -f "$pidfile"; kill 0' EXIT
+echo "Backend:      http://localhost:${PORT}" >&2
+echo "Frontend:     http://localhost:${VITE_PORT}" >&2
+echo "DATABASE_URL: ${DATABASE_URL}" >&2
+echo "Logs:         ${log_dir}/ (follow from elsewhere: bin/dev logs)" >&2
+
+# Children: `exec` so $! is the real service process (recorded in state.env
+# for app_dev_stop's orphan sweep); output goes to the log files only — the
+# tail below streams the combined view to this terminal, so interactive
+# behavior is unchanged while agents and post-mortems read the files.
+#
+# set -m: each background child becomes its OWN process-group leader, so
+# cleanup/app_dev_stop can `kill -- -pid` a service's whole subtree (bun run →
+# vite) without signalling this script's inherited group, which the caller of
+# 'bin/dev stop' can share. disown (below) drops them from the job table so
+# job-control status lines don't pollute stderr; kill -0 monitoring is
+# pid-based and unaffected.
+set -m
 
 # Backend. HOST defaults to LOOPBACK — widen to 0.0.0.0 only deliberately (LAN /
 # mobile-device testing), and NEVER while a dev-auth bypass is active: an
 # AUTH_DISABLED-style mode that treats every request as admin is only safe
 # because it's loopback-contained. Don't export 0.0.0.0 unconditionally.
-env DATABASE_URL="$DATABASE_URL" PORT="$PORT" HOST="${HOST:-127.0.0.1}" \
-  bash -c 'cd "$0"/<server-subdir> && bun run dev' "$root" &
+( cd "$(app_server_dir)" && exec env DATABASE_URL="$DATABASE_URL" PORT="$PORT" \
+  HOST="${HOST:-127.0.0.1}" bun run dev >>"$log_dir/server.log" 2>&1 ) &
+server_pid=$!
 
-# Repos with N backend processes per worktree (e.g. gRPC service + HTTP gateway):
-# start each the same way with its own picked port, threading the wiring env into
-# dependents — they all die via the same trap:
-#   GRPC_PORT="$(app_pick_grpc_port)"
-#   env DATABASE_URL="$DATABASE_URL" GRPC_PORT="$GRPC_PORT" \
-#     bash -c 'cd "$0"/<grpc-subdir> && bun run dev' "$root" &
-#   ...and pass ORCHESTRATOR_URL="http://localhost:${GRPC_PORT}" to consumers.
+# Repos with N backend processes per worktree (e.g. gRPC service + HTTP
+# gateway): start each the same way — own picker, own log file, own
+# <NAME>_PID + <NAME>_PID_LSTART in the state write below, and add it to the
+# health-check/stop key lists in _common.sh. Thread the wiring env into
+# dependents (e.g. ORCHESTRATOR_URL="localhost:${GRPC_PORT}").
 
-# Frontend — proxy to the actual backend port (important for non-default worktree
-# ports). Convention: name the var VITE_API_TARGET (what real adopters use; the
-# vite config reads it to set server.proxy) rather than a bare API_TARGET. Proxy
-# /auth as well as /api when dev session cookies ride the proxy — a /api-only
-# proxy silently breaks login.
-(cd "$root/<web-subdir>" && VITE_API_TARGET="http://localhost:${PORT}" VITE_PORT="$VITE_PORT" bun run dev) &
+# Frontend — proxy to the actual backend port (important for non-default
+# worktree ports). Convention: name the var VITE_API_TARGET (the vite config
+# reads it to set server.proxy) rather than a bare API_TARGET. Proxy /auth as
+# well as /api when dev session cookies ride the proxy — a /api-only proxy
+# silently breaks login.
+( cd "$root/<web-subdir>" && exec env VITE_PORT="$VITE_PORT" \
+  VITE_API_TARGET="http://localhost:${PORT}" bun run dev >>"$log_dir/web.log" 2>&1 ) &
+web_pid=$!
 
-wait
+# Combined live stream for this terminal (-q: no per-file headers — the
+# per-service files are the labeled view).
+tail -q -n +1 -F "$log_dir/server.log" "$log_dir/web.log" 2>/dev/null &
+tail_pid=$!
+disown -a
+set +m
+
+# Hold PHASE=booting until both ports actually listen — there's a real window
+# where every process is alive but nothing is bound yet (deps loading, the app
+# self-migrating), and "running" must mean attachable (the health check that
+# status/attach run against this file checks the ports). A child dying during
+# the wait aborts the boot loudly instead.
+boot_ready=0
+for i in $(seq 1 120); do
+  boot_ready=1
+  for port in "$PORT" "$VITE_PORT"; do
+    if ! port_in_use "$port"; then
+      boot_ready=0
+      break
+    fi
+  done
+  if [ "$boot_ready" = 1 ]; then
+    break
+  fi
+  for entry in "server:${server_pid}" "web:${web_pid}"; do
+    if ! kill -0 "${entry##*:}" 2>/dev/null; then
+      echo "bin/dev: ${entry%%:*} exited during startup (see ${log_dir}/${entry%%:*}.log)" >&2
+      exit 1
+    fi
+  done
+  sleep 1
+done
+if [ "$boot_ready" != 1 ]; then
+  echo "bin/dev: services did not bind their ports within 2 minutes — tearing down (see ${log_dir}/)" >&2
+  exit 1
+fi
+
+# Full state, atomically replacing the PHASE=booting claim (write-then-mv so
+# a concurrent status/attach never reads a half-written file). Every pid is
+# recorded with its start time — the identity that keeps stale state from
+# ever matching (or killing) a recycled pid.
+{
+  echo "PHASE=running"
+  echo "DEV_PID=$$"
+  echo "DEV_PID_LSTART=$(app_pid_lstart $$)"
+  echo "DATABASE_URL=${DATABASE_URL}"
+  echo "PORT=${PORT}"
+  echo "VITE_PORT=${VITE_PORT}"
+  echo "SERVER_PID=${server_pid}"
+  echo "SERVER_PID_LSTART=$(app_pid_lstart "$server_pid")"
+  echo "WEB_PID=${web_pid}"
+  echo "WEB_PID_LSTART=$(app_pid_lstart "$web_pid")"
+  echo "TAIL_PID=${tail_pid}"
+  echo "TAIL_PID_LSTART=$(app_pid_lstart "$tail_pid")"
+  echo "STARTED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+} >"$state_file.tmp"
+mv "$state_file.tmp" "$state_file"
+
+# ── Supervise: one dies → all die, loudly ──────────────────────────────────
+# A plain `wait` here is exactly how half-dead stacks happen: one child
+# crashes and the other keeps serving errors from a bound port. Poll instead
+# (`wait -n` needs bash ≥ 4.3; macOS ships 3.2) and name the corpse.
+#
+# The same loop caps log growth for long-lived sessions (checked every ~60s):
+# past APP_DEV_LOG_CAP_BYTES (default 20 MB ≈ days of local noise) the last
+# half is kept in <service>.log.old and the live file is truncated IN PLACE —
+# safe because the children write with O_APPEND (>>), so their next write
+# lands at the new EOF, and the terminal's tail -F follows truncation. Lines
+# written between the tail-copy and the truncate are dropped; for dev logs
+# that sliver is acceptable.
+log_cap_bytes="${APP_DEV_LOG_CAP_BYTES:-20971520}"
+log_keep_bytes=$((log_cap_bytes / 2))
+tick=0
+while true; do
+  sleep 2
+  for entry in "server:${server_pid}" "web:${web_pid}"; do
+    if ! kill -0 "${entry##*:}" 2>/dev/null; then
+      name="${entry%%:*}"
+      echo "" >&2
+      echo "bin/dev: ${name} exited — tearing down the stack (see ${log_dir}/${name}.log)" >&2
+      exit 1
+    fi
+  done
+  tick=$((tick + 1))
+  if [ $((tick % 30)) -eq 0 ]; then
+    for name in server web; do
+      f="$log_dir/${name}.log"
+      size="$(wc -c <"$f" 2>/dev/null || echo 0)"
+      if [ "$size" -gt "$log_cap_bytes" ]; then
+        tail -c "$log_keep_bytes" "$f" >"${f}.old"
+        : >"$f"
+      fi
+    done
+  fi
+done

--- a/skills/agent-dev-workflow/references/bin/gc
+++ b/skills/agent-dev-workflow/references/bin/gc
@@ -1,0 +1,288 @@
+#!/usr/bin/env bash
+# Sweep merged agent worktrees. Enumerates this repo's linked worktrees under
+# any */.claude/worktrees/ path (including nested registrations like
+# apps/web/.claude/worktrees/*), PROVES each one disposable, and for the
+# proven ones: stops any recorded bin/dev session, drops the derived
+# per-worktree database, removes the worktree, deletes the local branch, and
+# finally prunes stale remote-tracking refs. State-based, not event-based:
+# merged-ness is a property git can verify at any later time, so this runs
+# lazily — manually, or nudged at session start. Ported from the open-source
+# continuous-gtfs repo's bin/gc (its PRs #290/#293).
+#
+#   bin/gc            # sweep (applies by default)
+#   bin/gc --dry-run  # print the same verdicts; mutate nothing
+#   bin/gc --nudge    # SessionStart-hook mode: no fetch, no network, no
+#                     # mutation — cached refs + cheap gates only; prints one
+#                     # summary line when candidates exist, NOTHING when none
+#
+# Proof of disposability = ALL mandatory gates + AT LEAST ONE containment
+# proof. Containment is computed after a fresh `git fetch origin` (dry-run
+# fetches too — verdicts must never be read off a stale base ref; --nudge
+# alone skips the fetch):
+#
+#   Gates: not the main worktree; not the worktree gc is invoked from
+#   (fully-resolved path compare); clean working tree (no modifications, no
+#   untracked-unignored files); not locked; not a long-lived branch.
+#
+#   Containment (any one suffices):
+#     ancestry        — HEAD is an ancestor of the base ref
+#     patch-contained — every commit in <base>..HEAD reports `-` from
+#                       `git cherry` (catches PRs rebased remotely pre-merge)
+#     merged PR       — `gh pr list --head <branch> --state merged` hits
+#                       (catches squash merges, where patch-ids break).
+#                       Best-effort: silently unavailable when gh is missing
+#                       or errors. Never consulted for closed-unmerged PRs.
+#
+# Anything unproven is skipped with a one-line reason. Exit 0 either way.
+# Never touches the canonical main-worktree database, stashes (repo-global,
+# not attributable to a worktree), or remote branches (GitHub deletes those
+# on merge).
+#
+# Env overrides: APP_PG_PORT, APP_GC_BASE_REF.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/_common.sh"
+
+# The ref merges land on — containment is proven against THIS. Set it to the
+# repo's integration branch: origin/main by default; export (or hard-code)
+# APP_GC_BASE_REF=origin/develop in repos that integrate on develop.
+base_ref="${APP_GC_BASE_REF:-origin/main}"
+
+usage() { echo "usage: bin/gc [--dry-run|--nudge]"; }
+
+mode="apply"
+case "${1:-}" in
+  "") ;;
+  --dry-run) mode="dry" ;;
+  --nudge) mode="nudge" ;;
+  -h|--help) usage; exit 0 ;;
+  *)
+    echo "bin/gc: unknown argument '$1'" >&2
+    usage >&2
+    exit 2
+    ;;
+esac
+
+# Fully-resolved physical path (macOS has no realpath pre-Ventura).
+gc_resolve() { (cd "$1" 2>/dev/null && pwd -P) || printf '%s\n' "$1"; }
+
+# Anchor every repo-level git command on the script's own worktree — cwd may
+# be anywhere (the SessionStart hook runs from the project dir; a human may
+# run this from an unrelated directory).
+self_root="$(gc_resolve "$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)")"
+main_root="$(gc_resolve "$(git -C "$self_root" worktree list --porcelain | head -1 | sed 's/^worktree //')")"
+# The worktree gc is invoked FROM can differ from the one it lives in (e.g.
+# running another worktree's bin/gc). Exclude both.
+invoke_root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+if [ -n "$invoke_root" ]; then
+  invoke_root="$(gc_resolve "$invoke_root")"
+fi
+
+# The one database this tool must never be able to drop.
+canonical_db="$(app_db_name_for_root "$main_root")"
+
+# Verdict lines (stdout). --nudge stays silent per-worktree — it only counts.
+report() { [ "$mode" = "nudge" ] || echo "$*"; }
+
+if [ "$mode" != "nudge" ]; then
+  if ! git -C "$self_root" fetch origin --quiet; then
+    # Stale refs can only UNDER-prove (the base ref moves forward), never
+    # over-prove — safe to continue, but say so.
+    echo "bin/gc: warning: git fetch origin failed — verdicts computed against cached refs" >&2
+  fi
+fi
+
+if ! git -C "$self_root" rev-parse --verify --quiet "$base_ref" >/dev/null; then
+  [ "$mode" = "nudge" ] || echo "bin/gc: ${base_ref} not found — nothing can be proven" >&2
+  exit 0
+fi
+
+# ── Enumerate linked worktrees ──────────────────────────────────────────────
+# Parse `git worktree list --porcelain` records into tab-separated lines
+# (path, branch, locked, prunable) — bash 3.2: no mapfile, no assoc arrays.
+records=""
+rec_wt="" rec_br="" rec_locked=0 rec_prunable=0
+gc_flush_record() {
+  if [ -n "$rec_wt" ]; then
+    records="${records}${rec_wt}"$'\t'"${rec_br}"$'\t'"${rec_locked}"$'\t'"${rec_prunable}"$'\n'
+  fi
+  rec_wt="" rec_br="" rec_locked=0 rec_prunable=0
+}
+while IFS= read -r line; do
+  case "$line" in
+    "worktree "*) gc_flush_record; rec_wt="${line#worktree }" ;;
+    "branch refs/heads/"*) rec_br="${line#branch refs/heads/}" ;;
+    locked*) rec_locked=1 ;;
+    prunable*) rec_prunable=1 ;;
+  esac
+done < <(git -C "$self_root" worktree list --porcelain)
+gc_flush_record
+
+# ── Evaluate + act ──────────────────────────────────────────────────────────
+candidates=0
+nudge_count=0
+removed_any=0
+
+# The record stream rides fd 3, NOT stdin: commands inside the loop
+# (docker exec -i via app_psql, gh) read stdin and would silently slurp the
+# remaining records after the first removal — the rest of the sweep would
+# never happen.
+while IFS=$'\t' read -r -u 3 wt br locked prunable; do
+  [ -n "$wt" ] || continue
+  case "$wt" in
+    */.claude/worktrees/*) ;;
+    *) continue ;; # out of scope (includes the main worktree, structurally)
+  esac
+  candidates=$((candidates + 1))
+  rwt="$(gc_resolve "$wt")"
+  rel="${rwt#"$main_root"/}"
+
+  # Mandatory gates — all must hold before any containment proof is consulted.
+  if [ "$rwt" = "$main_root" ]; then
+    report "skipped ${rel}: main worktree"
+    continue
+  fi
+  if [ "$rwt" = "$self_root" ] || [ "$rwt" = "$invoke_root" ]; then
+    report "skipped ${rel}: current worktree (bin/gc invoked from it)"
+    continue
+  fi
+  if [ "$prunable" = 1 ] || [ ! -d "$rwt" ]; then
+    report "skipped ${rel}: directory missing (see 'git worktree prune')"
+    continue
+  fi
+  if [ "$locked" = 1 ]; then
+    report "skipped ${rel}: locked"
+    continue
+  fi
+  if [ -z "$br" ]; then
+    report "skipped ${rel}: detached HEAD"
+    continue
+  fi
+  # A long-lived branch checked out in an agent worktree is an anomaly, and
+  # the integration branch trivially proves ancestry-contained — without this
+  # gate the sweep would remove the worktree AND `git branch -D` it. Never
+  # evaluate one.
+  case "$br" in
+    main|master|develop)
+      report "skipped ${rel}: long-lived branch '${br}' checked out"
+      continue
+      ;;
+  esac
+  if ! dirty="$(git -C "$rwt" status --porcelain 2>/dev/null)"; then
+    report "skipped ${rel}: git status failed"
+    continue
+  fi
+  if [ -n "$dirty" ]; then
+    report "skipped ${rel}: dirty working tree (uncommitted or untracked files)"
+    continue
+  fi
+
+  # Containment proofs — any one suffices.
+  proof=""
+  if git -C "$rwt" merge-base --is-ancestor HEAD "$base_ref" 2>/dev/null; then
+    proof="ancestry: HEAD contained in ${base_ref}"
+  else
+    cherry="$(git -C "$rwt" cherry "$base_ref" HEAD 2>/dev/null)" || cherry="+ unavailable"
+    # Empty cherry output with failed ancestry proves nothing; require at
+    # least one commit, all reported `-` (patch present in the base ref).
+    if [ -n "$cherry" ] && ! printf '%s\n' "$cherry" | grep -q '^+'; then
+      proof="patch-contained: every ${base_ref}..HEAD commit already in ${base_ref} (git cherry)"
+    elif [ "$mode" != "nudge" ] && command -v gh >/dev/null 2>&1; then
+      # Best-effort gh layer (network) — never consulted in --nudge mode.
+      # `gh pr list --head` matches by branch NAME, so pin the merged PR's
+      # head OID to this worktree's HEAD before trusting it: a reused branch
+      # name carrying fresh commits (old merged PR, new unmerged work) must
+      # never prove anything. Costs a real case — a branch rebased remotely
+      # pre-merge no longer OID-matches its own PR and stays skipped — but
+      # in a deletion tool a false skip is noise, a false proof is data loss.
+      pr_line="$( (cd "$rwt" && gh pr list --head "$br" --state merged --limit 1 \
+        --json number,headRefOid --jq '.[] | "\(.number) \(.headRefOid)"') 2>/dev/null || true)"
+      if [ -n "$pr_line" ] && [ "${pr_line#* }" = "$(git -C "$rwt" rev-parse HEAD)" ]; then
+        proof="PR #${pr_line%% *} merged (head matches)"
+      fi
+    fi
+  fi
+  if [ -z "$proof" ]; then
+    report "skipped ${rel}: no containment proof (branch '${br}' not merged into ${base_ref})"
+    continue
+  fi
+
+  if [ "$mode" = "nudge" ]; then
+    nudge_count=$((nudge_count + 1))
+    continue
+  fi
+  if [ "$mode" = "dry" ]; then
+    echo "would remove ${rel} (${proof})"
+    continue
+  fi
+
+  # ── Apply ────────────────────────────────────────────────────────────────
+  echo "removing ${rel} (${proof})"
+
+  # Stop any recorded bin/dev session for THAT worktree: the session helpers
+  # compute paths from app_root of the current dir, so subshell-cd into it —
+  # the same way bin/dev's own children run.
+  (cd "$rwt" && app_dev_stop) || true
+
+  db="$(app_db_name_for_root "$rwt")"
+  # Structurally never the canonical DB (main worktree excluded above), but
+  # guard anyway — this tool must not be able to drop the canonical database.
+  if [ "$db" != "$canonical_db" ] &&
+    [ "$(docker inspect -f '{{.State.Running}}' "$APP_CONTAINER_NAME" 2>/dev/null || true)" = "true" ]; then
+    exists="$(app_psql -d postgres -tAc "SELECT 1 FROM pg_database WHERE datname = '${db}'" 2>/dev/null || true)"
+    if [ "$exists" = "1" ]; then
+      app_psql -d postgres -c "
+        SELECT pg_terminate_backend(pid) FROM pg_stat_activity
+        WHERE datname = '${db}' AND pid <> pg_backend_pid()
+      " >/dev/null 2>&1 || true
+      # A client reconnecting between the terminate and the drop (a user
+      # psql/GUI session — the worktree's own bin/dev is already stopped)
+      # makes DROP fail; under set -e an unguarded failure would abort the
+      # whole sweep mid-run, breaking the exit-0-either-way contract. Skip
+      # this worktree instead — the next sweep retries.
+      if ! app_psql -d postgres -c "DROP DATABASE IF EXISTS ${db}" >/dev/null 2>&1; then
+        echo "skipped ${rel}: DROP DATABASE ${db} failed (still in use?) — retry next sweep"
+        continue
+      fi
+      echo "  dropped database ${db}"
+    fi
+  fi
+
+  # `git worktree remove` refusing (dirty/locked race since our check) is a
+  # feature — treat it as a skip, not an error.
+  if err="$(git -C "$self_root" worktree remove "$rwt" 2>&1)"; then
+    echo "  worktree removed"
+  else
+    echo "skipped ${rel}: git worktree remove refused (${err})"
+    continue
+  fi
+
+  # -D, not -d: a remotely-rebased-then-merged branch is not an ancestor of
+  # its own upstream, so plain -d refuses even though the PR merged.
+  if git -C "$self_root" branch -D "$br" >/dev/null 2>&1; then
+    echo "  branch ${br} deleted"
+  else
+    echo "  branch ${br} not deleted (already gone or checked out elsewhere)"
+  fi
+  removed_any=1
+done 3<<<"$records"
+
+if [ "$mode" = "nudge" ]; then
+  # One line when there is something to do; NOTHING when there isn't — this
+  # runs at every session start and must not pollute quiet ones.
+  if [ "$nudge_count" -gt 0 ]; then
+    echo "bin/gc: ${nudge_count} worktree(s) look merged — run bin/gc to sweep"
+  fi
+  exit 0
+fi
+
+if [ "$candidates" -eq 0 ]; then
+  echo "no agent worktrees found (nothing under */.claude/worktrees/)"
+fi
+
+if [ "$removed_any" = 1 ]; then
+  git -C "$self_root" remote prune origin >/dev/null 2>&1 || true
+  echo "pruned stale remote-tracking refs (git remote prune origin)"
+fi
+
+exit 0

--- a/skills/agent-dev-workflow/references/gotchas.md
+++ b/skills/agent-dev-workflow/references/gotchas.md
@@ -120,3 +120,76 @@ the old container (and possibly the volume) once, deliberately.
 Linux/coreutils has `md5sum`; BSD/macOS has `md5 -q`. The `app_hash` helper
 branches on which exists so worktree DB names are stable on both. Don't hard-code
 `md5sum`.
+
+## `trap 'kill 0' EXIT` can kill the caller
+
+`kill 0` signals the **whole process group** — which is not "my children". A
+script launched from a non-interactive shell (another script, a CI step, an
+agent's exec call) *shares* its caller's process group, so a supervisor that
+traps `kill 0` on EXIT takes the caller down with it the moment anything asks it
+to stop. This is exactly the failure the old fullstack `dev` template had:
+`bin/cleanup` would kill the dev session and then die mid-cleanup, killed by the
+session's own trap.
+
+Fix (in the current `dev-fullstack` template): `set -m` before backgrounding
+children so **each child leads its own process group**, record the child pids,
+and have the trap `kill -- -$child_pid` each group individually. That kills each
+service's whole subtree (`bun run` → vite) without ever signalling the script's
+inherited group.
+
+## PIDs get recycled — record and verify start-time identity before killing
+
+A pid file (or a `state.env`) can outlive its process: SIGKILL skips traps,
+reboots reset the pid space, and the OS reuses pids. A later `kill -0 $pid`
+proving "something is alive at that pid" is not proof it's *your* process — and
+blindly `kill`ing it can shoot an innocent bystander. Record each pid **with its
+start time** and re-verify before every liveness verdict and every kill:
+
+```bash
+app_pid_lstart() {          # start time of a live process; empty when gone
+  { ps -o lstart= -p "$1" 2>/dev/null || true; } | sed 's/^ *//;s/ *$//'
+}
+# store: echo "SERVER_PID_LSTART=$(app_pid_lstart "$server_pid")"
+# check: [ "$(app_pid_lstart "$pid")" = "$recorded_lstart" ]
+```
+
+The `_common.sh` template carries this as `app_pid_is`; the fullstack `dev` and
+`gc` templates consult it before every kill and every health verdict.
+
+## Commands that read stdin inside `while read` loops silently eat the stream
+
+`docker exec -i` (what `app_psql` wraps), `gh`, `ssh`, `ffmpeg` — anything that
+reads stdin — will, inside a `while read` loop fed on stdin, slurp the rest of
+the loop's input as *its* stdin. No error: the loop just ends after the first
+iteration that ran such a command. In a sweep like `bin/gc` that means "removed
+one worktree, silently skipped the rest".
+
+Fix: feed the loop on a **different file descriptor** so the commands inside
+keep their normal stdin:
+
+```bash
+while IFS=$'\t' read -r -u 3 wt br locked prunable; do
+  ...app_psql / gh calls...
+done 3<<<"$records"
+```
+
+(`read -u 3` + `3<<<` — the gc template does exactly this.)
+
+## macOS `TMPDIR` has a trailing slash — `"$TMPDIR"/*` patterns break
+
+On macOS, `TMPDIR` is set to something like `/var/folders/.../T/` — **with a
+trailing slash**. Appending `/*` yields `.../T//*`, and in a `case` glob (or any
+pattern match) the double slash must match literally, so real tmp paths (from
+`mktemp -d`, no double slash) silently fail the match. Anything gated on "is
+this path under tmp?" — e.g. a guard that only `rm -rf`s recorded paths inside
+tmp — then never fires on macOS.
+
+Fix: strip the trailing slash before appending (two steps — bash can't nest
+`${${TMPDIR:-/tmp}%/}`):
+
+```bash
+tmp="${TMPDIR:-/tmp}"; tmp="${tmp%/}"
+case "$path" in
+  /tmp/*|"$tmp"/*) rm -rf "$path" ;;
+esac
+```

--- a/skills/agent-dev-workflow/references/orchestrator-integration.md
+++ b/skills/agent-dev-workflow/references/orchestrator-integration.md
@@ -19,15 +19,52 @@ with zero manual config. These scripts provide exactly that contract.
   emit both forms (`app_db_env`).
 - **run** → `bin/dev` (or `bin/server`). Picks the same free ports and derives the
   same DB, so it works whether or not the orchestrator threaded `setup`'s output
-  through. Uses `exec` for clean signal handling. Binds **loopback by default**
+  through. The single-service variant `exec`s for clean signal handling; the
+  fullstack variant is a supervised singleton with its own attach/status/stop
+  contract (next section). Binds **loopback by default**
   (`HOST=127.0.0.1`): an orchestrator that needs LAN exposure must opt in
   explicitly — and must never widen a dev-auth-bypass instance (an
   AUTH_DISABLED-style everyone-is-admin mode) beyond loopback. If the
   orchestrator health-checks the service, `curl` works for HTTP ports but **not
   gRPC** — probe those with a plain TCP connect.
 - **cleanup** → `bin/cleanup`. Drops this worktree's DB (refuses the canonical
-  one without `--force`); stops the dev session if a fullstack `bin/dev` left a
-  PID file. Leaves the shared container up for other worktrees.
+  one without `--force`); stops the recorded dev session first (`app_dev_stop`
+  handles both `.dev/state.env` sessions and legacy `.dev.pid` ones). Leaves
+  the shared container up for other worktrees.
+
+## The dev-session contract (fullstack `bin/dev`)
+
+The fullstack `dev` template is a **per-worktree singleton** with an explicit
+machine contract, so an orchestrator (or a second agent in the same worktree)
+can discover, attach to, health-check, and stop a session without guessing:
+
+- **Singleton + attach.** One session per worktree. A second `bin/dev` against
+  a healthy session starts nothing — it prints the running session's endpoints
+  and exits 0. A session still *booting* (another `bin/dev`'s pre-flight:
+  postgres ensure, migrate) is waited on and then attached, never torn down. A
+  stale or half-dead session (a child gone, recycled pids after a reboot) is
+  torn down and replaced automatically. `bin/dev --restart` bounces whatever is
+  there.
+- **`KEY=VALUE` on stdout.** Start and attach both emit the session's env block
+  (`STATUS=running`, `DEV_PID`, `DATABASE_URL`, `PORT`, `VITE_PORT`, `LOG_DIR`)
+  on stdout — human status stays on stderr, same discipline as `bin/setup` — so
+  one stdout capture tells the orchestrator where the stack landed either way.
+- **`bin/dev status` exit codes.** `0` running (healthy: every recorded pid is
+  the exact recorded process *and* every port listens) / `1` stopped (no
+  session) / `2` unhealthy (recorded session not fully up — replace or stop it)
+  / `3` starting (boot in progress — re-check shortly, or run `bin/dev` to wait
+  and attach). Script against the codes; the stdout block accompanies 0 and 3.
+- **On-disk logs.** Each service's full output lands in
+  `.dev/logs/<service>.log` (e.g. `server.log`, `web.log`) — fresh per session,
+  kept after exit for post-mortems, size-capped for long-lived sessions
+  (`APP_DEV_LOG_CAP_BYTES`). Agents read the files; humans can `bin/dev logs
+  [service]` from any terminal.
+- **Attach refusal on mismatch.** Attaching exits 2 when the running session
+  wasn't started with the caller's explicit `DATABASE_URL`/`PORT`/`VITE_PORT`
+  overrides — never exit 0 with settings the caller didn't ask for.
+- **`bin/dev stop`** stops the recorded session from any terminal; one child
+  dying tears down the whole stack loudly (never a half-dead session serving
+  errors from still-bound ports).
 
 ## Why stdout/stderr discipline matters
 


### PR DESCRIPTION
Closes #36. Ports the hardened dev-session protocol from continuous-gtfs (its PRs [#290](https://github.com/JarvusInnovations/continuous-gtfs/pull/290) and [#293](https://github.com/JarvusInnovations/continuous-gtfs/pull/293), both merged and running in daily use) into the `agent-dev-workflow` reference templates.

## Why replace rather than add a variant

The current `dev-fullstack` template uses `trap 'kill 0' EXIT` and a bare `.dev.pid` — the exact two mechanisms whose failure loop was observed in mixed human + agent use (a `kill 0` takes down a `stop` caller sharing the process group; a second `bin/dev` clobbers the pidfile so cleanup kills the wrong session; orphaned children keep serving errors from bound ports). Keeping a variant known-broken for the skill's stated use case re-arms the trap, so the template is replaced outright. The simple single-service `dev` stays for no-concurrency projects.

## What changed

- **`references/bin/dev-fullstack`** (54 → 383 lines): per-worktree singleton sessions — atomic noclobber claim (`PHASE=booting` → write-tmp-then-mv `PHASE=running` once ports actually listen), attach instead of racing (`KEY=VALUE` endpoints on stdout, exit 0), wait-attach on a booting session with takeover on claim-owner death, attach refusal on explicit env-override mismatch, pid+lstart identity verified before every kill and health verdict, per-child process groups via `set -m` (no `kill 0` anywhere), one-dies-all-die supervision (bash-3.2 poll loop, no `wait -n`), on-disk size-capped logs under `.dev/logs/`, `status`/`stop`/`logs` subcommands with a machine exit-code contract (0 running / 1 stopped / 2 unhealthy / 3 starting), legacy `.dev.pid` handling. Collapsed to the template's two-service model (backend + frontend) with a comment on extending to N backend processes.
- **`references/bin/gc`** (new): state-based sweep of merged agent worktrees under `*/.claude/worktrees/`. Removal requires all mandatory gates (not main/invocation worktree, clean, unlocked, not detached, not a long-lived branch) plus at least one containment proof computed after a fresh fetch — ancestry, `git cherry` patch-containment (non-empty required, so backmerge-shaped branches can't false-prove), or a merged PR with the head OID pinned to the worktree's HEAD. Drops the derived per-worktree database behind a computed canonical-DB guard; `--dry-run` previews, `--nudge` is the offline no-mutation SessionStart hook mode. Base ref is `APP_GC_BASE_REF` (default `origin/main`).
- **`references/bin/_common.sh`**: session-state/snapshot helpers, `app_pid_lstart`/`app_pid_is`, `app_dev_stop` (shared by `stop` and `bin/cleanup`), `app_db_name_for_root`.
- **`references/orchestrator-integration.md`**: the dev-session contract — exactly what an orchestrator wants to consume (attach output, exit codes, log paths).
- **`references/gotchas.md`**: four new entries — `kill 0` process-group hazard, pid recycling → lstart identity, stdin-reading commands inside `while read` loops silently slurping the stream (→ fd 3), macOS `TMPDIR` trailing-slash glob breakage.
- **`SKILL.md`**: session state machine + identity checks + gc proofs added to the copy-verbatim invariant list; new worktree-lifecycle section (create under `.claude/worktrees/`, gitignore `**/.claude/worktrees/`, gc sweeps after merge; out-of-tree worktrees escape the sweep); verify list extended (second `bin/dev` attaches, kill-a-child → whole stack exits, `bin/gc --dry-run`).

## Verification

`bash -n` clean on all templates; `_common.sh` helpers smoke-tested live (recycled-pid and empty-pid refusals correct); `bin/gc --nudge`/`--dry-run`/bad-arg exercised (silent exit 0 / verdict output / usage exit 2). The source protocol's own validation: the framework's PR #290 validation matrix (attach, status codes, child-kill teardown, cross-terminal stop, recycled-pid state, SIGKILLed-supervisor sweep) and #293's synthetic + live sweeps, plus an adversarial review of the deletion gates before merge.

A known follow-up stream exists upstream ([continuous-gtfs#301](https://github.com/JarvusInnovations/continuous-gtfs/issues/301) — narrow-window claim/teardown races found in review, none corrupting); when those land there, they should flow through here too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<https://claude.ai/code/session_01AasYP1wffZa9xrosJ6Nnzk>
