### PR TITLE
docs(jarvus-dbt): fast (<5 min) dev-loop requirement + no unvalidated demo work in main

### DIFF
--- a/skills/jarvus-dbt/README.md
+++ b/skills/jarvus-dbt/README.md
@@ -4,9 +4,10 @@ Jarvus's house conventions for **writing, testing, and linting dbt** — the opi
 that sits on top of [dbt-labs' first-party dbt skills](https://github.com/dbt-labs/dbt-agent-skills)
 (which cover the mechanics). It encodes how our dbt lead wants models built: stage discipline
 (staging never dedups/aggregates), deliberate materialization and grain, no inner joins,
-import-CTEs-at-top, semantic table aliases, the generic + quality-model + unit-test patterns,
-and a `sqlfluff` + CI setup — including a **credential-free multi-tenant CI gate** for
-the DuckDB stack.
+import-CTEs-at-top, semantic table aliases, a **fast (<5 min) local dev loop** as a project
+requirement, **no unvalidated demo work in `main`**, the generic + quality-model + unit-test
+patterns, and a `sqlfluff` + CI setup — including a **credential-free multi-tenant CI gate**
+for the DuckDB stack.
 
 ## When you'd want it
 

--- a/skills/jarvus-dbt/SKILL.md
+++ b/skills/jarvus-dbt/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: jarvus-dbt
-description: Jarvus house conventions for writing, testing, and linting dbt projects — model layering and grain, what each stage may/may not do, the no-inner-joins and semantic-alias rules, the generic + quality-model + unit-test patterns, the sqlfluff config, and a credential-free multi-tenant CI gate. Use when building or reviewing dbt models, deciding materialization or test coverage, setting up dbt linting/CI, or when "dbt", "sqlfluff", "staging/intermediate/marts", "dbt test", or "TIDES" come up. This is the opinionated house layer ON TOP OF dbt-labs' first-party dbt skills (which cover the mechanics) — see "Relationship to other skills".
+description: Jarvus house conventions for writing, testing, and linting dbt projects — model layering and grain, what each stage may/may not do, the no-inner-joins and semantic-alias rules, the fast (<5 min) local dev-loop requirement, the no-unvalidated-demo-work-in-main rule, the generic + quality-model + unit-test patterns, the sqlfluff config, and a credential-free multi-tenant CI gate. Use when building or reviewing dbt models, deciding materialization or test coverage, setting up dbt linting/CI, or when "dbt", "sqlfluff", "staging/intermediate/marts", "dbt test", or "TIDES" come up. This is the opinionated house layer ON TOP OF dbt-labs' first-party dbt skills (which cover the mechanics) — see "Relationship to other skills".
 ---
 
 # dbt practices (Jarvus house conventions)
@@ -44,6 +44,12 @@ These are the rules to apply on every model; rationale and examples in
   ("renamed from…", "replaced…").
 - **It must work for every tenant.** Changes parse and run across *all* configured
   tenants/projects, not just the one you touched — the CI gate enforces this.
+- **A fast (<5 min) dev loop is a project requirement.** Every dbt project needs a documented,
+  quickly runnable way to exercise it (local target, sampled slice, unit tests, `state:modified`)
+  so modeling work is never blocked by slow full-pipeline runs or remote fetch paths.
+- **Unvalidated demo work doesn't live in `main`.** Demos stay on branches; if they merged for
+  a demo, remove them after, leaving breadcrumbs (tag/branch + a note). Plausible-looking but
+  unvalidated models in the main DAG are a liability others can't ignore.
 
 ## Testing
 

--- a/skills/jarvus-dbt/references/conventions.md
+++ b/skills/jarvus-dbt/references/conventions.md
@@ -130,3 +130,52 @@ A change has to **parse and run across all configured tenants** (or target proje
 the one you edited — tenant-specific divergence hides bugs. The CI gate runs `dbt parse` for
 every tenant on each PR ([linting-and-ci.md](linting-and-ci.md)); don't merge on the strength
 of one tenant compiling.
+
+## A fast (<5 min) dev loop is a project requirement
+
+Every dbt project must have a documented, quickly runnable way to **exercise the project end to
+end in under ~5 minutes**. Local-only is fine — it doesn't have to be the production path. What
+it must do is give a developer editing models a quick feedback cycle, so data-modeling work is
+never blocked by pipeline performance — especially where there are slow fetch paths between
+remote sources and local dev.
+
+Treat this as part of **project setup**, not a later nicety: if iterating on a model requires a
+long remote fetch or a full rebuild, that's a project bug to fix *before* more modeling work
+piles onto it. Building blocks, cheapest first:
+
+- **dbt unit tests** — fixture-based, no data read at all ([testing.md](testing.md)).
+- **`dbt parse` / `dbt compile`** — catches ref/config/jinja errors with no data.
+- **`dbt build` against a small local target** — a local DuckDB target, a sampled/thin slice of
+  source data (seeds or a cached extract), or `--empty` runs to validate SQL shape.
+- **`state:modified` + deferral** (dbt-labs' `using-dbt-state`) — scope the build to changed
+  models instead of rebuilding the world.
+
+Whatever the combination, **write it down in the project README** ("how to iterate locally in
+<5 minutes") so it's the default workflow rather than tribal knowledge, and keep it working —
+a fast path that has rotted is the same as not having one.
+
+## Unvalidated demo work doesn't live in `main`
+
+Demo/spike models that haven't been **validated** don't get merged into the main dbt project —
+or, if they had to merge for a demo, they get **removed after the demo**, leaving breadcrumbs
+(a tag or branch preserving the code, plus a short note — README, ADR, or closing PR comment —
+saying what it was and where it lives) so someone doing similar work later can find it.
+
+Why this is a hard rule: once demo models are integrated into the main DAG, they're impossible
+to just ignore — they look plausible, other models can come to depend on them, and untangling
+an at-best-partially-correct implementation costs more than building fresh. It also poisons the
+project for whoever comes next: a repo full of plausible-looking but unvalidated models makes
+"start over vs. build on this" undecidable (is the package structure sound scaffolding, or is
+it as unvalidated as the models inside it?).
+
+In practice:
+
+- Demos live on a **branch** until the models are validated to the normal bar (tested grain,
+  reviewed logic — see [testing.md](testing.md)).
+- If demo code did land in `main`, **removal is the default** once the demo is over. Preserving
+  it is what the breadcrumbs are for; keeping it "because it might be useful" is how the DAG
+  accretes half-right models.
+- When you **inherit** a project containing plausible-looking but unvalidated work: treat the
+  structure as scaffolding at most, and require validation before treating any model as
+  correct. "Looks plausible" is not evidence. Prefer explicitly starting a model over from its
+  spec to incrementally untangling a partially-correct implementation.

--- a/skills/jarvus-dbt/references/linting-and-ci.md
+++ b/skills/jarvus-dbt/references/linting-and-ci.md
@@ -58,6 +58,10 @@ sqlfluff runs *directly* in CI (it emits PR annotations natively; see the gate b
 local fast feedback use a **sqlfluff editor integration** (the vscode-sqlfluff extension or a
 sqlfluff LSP) and run `sqlfluff lint` / `sqlfluff fix` by hand — don't wire a git hook.
 
+Lint feedback is only part of the loop: the project must also have a **<5-minute way to
+actually exercise the dbt project** (build/run, not just lint) — that requirement and its
+building blocks are in [conventions.md](conventions.md).
+
 ## The CI gate
 
 Path-filtered, **credential-free** for the DuckDB stack (it reads public data; no warehouse


### PR DESCRIPTION
Adds two house rules to the `jarvus-dbt` skill, distilled from hands-on project experience:

## 1. A fast (<5 min) dev loop is a project requirement

Every dbt project must have a documented, quickly runnable (**under ~5 minutes**) way to exercise the project. Local-only is fine — the point is a quick feedback cycle so data-modeling work is never blocked by pipeline performance, especially where there are slow fetch paths between remote sources and local dev. Treated as part of project setup, not a later nicety, with building blocks listed cheapest-first (unit tests → parse/compile → small local target / sampled slice / `--empty` → `state:modified` + defer) and a requirement that the path be written down in the project README.

## 2. Unvalidated demo work doesn't live in `main`

Demo/spike models that haven't been validated don't merge into the main dbt project — or, if they merged for a demo, they're removed after, with breadcrumbs (tag/branch + a short note) so future similar work can find them. Rationale captured in `conventions.md`: once integrated into the main DAG, plausible-looking but partially-correct models are impossible to ignore, expensive to untangle, and make the "start over vs. build on this" call undecidable for whoever inherits the project. Includes guidance for the inheritance case: treat structure as scaffolding at most, require validation before trusting any model, and prefer explicit start-over to incremental untangling.

## Changes

- `references/conventions.md` — the two full rules with rationale
- `SKILL.md` — at-a-glance bullets + description keywords
- `references/linting-and-ci.md` — cross-link from the local-feedback section (lint feedback ≠ a way to exercise the project)
- `README.md` — mention in the summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)