### PR TITLE
refactor(jarvus-react): align bootstrap contract and reference boundaries

### DIFF
--- a/skills/jarvus-react/README.md
+++ b/skills/jarvus-react/README.md
@@ -2,15 +2,16 @@
 
 The Jarvus convention set for building frontends with **Bun + Vite + React 19 + Tailwind CSS v4 +
 React Router v7** — project setup, routing, styling, layout, and the `cn()` helper, the way Jarvus
-builds React apps. Bun is the runtime, package manager, and script runner. **shadcn/ui is an
+builds React apps. Bun manages dependencies and runs project scripts. **shadcn/ui is an
 optional layer** on top of this base stack (see `references/shadcn.md`), not a default.
 
 ## When you'd want it
 
-Any project with this React frontend stack — scaffolding a new app, implementing routing, styling
-with Tailwind, or building UI components. Install it on a repo so an agent working on the UI follows
-the house conventions (the `@tailwindcss/vite` plugin, `react-router` v7 imports, the `@/` path
-alias, the `cn()` helper). Adopt shadcn/ui per-project when you want a ready-made component set.
+Use it when a repository already uses this React frontend stack, or when you explicitly want to
+bootstrap or migrate to it. Install it on a repo so an agent working on the UI follows the house
+conventions (the `@tailwindcss/vite` plugin, pinned `react-router` v7 imports, the `@/` path alias,
+and the `cn()` helper) without replacing another package manager, framework, or routing mode by
+accident. Adopt shadcn/ui per-project when you want a ready-made component set.
 
 ## Install
 

--- a/skills/jarvus-react/SKILL.md
+++ b/skills/jarvus-react/SKILL.md
@@ -1,89 +1,62 @@
 ---
 name: jarvus-react
-description: Frontend development using Bun + Vite + React + Tailwind CSS + React Router v7. Use when creating new frontend projects, adding UI components, implementing routing, styling with Tailwind, or working with the React frontend stack. shadcn/ui is an optional component-library layer (see references/shadcn.md).
+description: Build or maintain Jarvus frontend applications that use Bun, Vite, React 19, TypeScript, Tailwind CSS v4, and React Router v7. Use when a repository already uses this stack or when the user explicitly asks to bootstrap or migrate to it; preserve an existing package manager, framework, and routing mode unless migration is requested. shadcn/ui is optional.
 ---
 
-# Frontend React Stack (Bun)
+# Jarvus React
 
-Modern React frontend stack, run on **Bun**:
+Use this skill for the Jarvus React base stack:
 
-- **Bun** - Runtime, package manager, and script runner (no Node.js or npm)
-- **Vite** - Build tooling and dev server
-- **React 19** - UI framework
-- **TypeScript** - Type safety
-- **Tailwind CSS v4** - Utility-first styling (`@tailwindcss/vite` plugin)
-- **React Router v7** - Client-side routing (package `react-router`, not `react-router-dom`)
-- **`cn()` helper** - `clsx` + `tailwind-merge` for conditional classes
+- Bun for dependency management and scripts
+- Vite, React 19, and TypeScript
+- Tailwind CSS v4 through `@tailwindcss/vite`
+- React Router v7 through `react-router`
+- `clsx` plus `tailwind-merge` for conditional classes
 
-**Component library is a choice, not a default.** This skill is the React base stack.
-**shadcn/ui** is a popular, optional layer on top — when a project wants it, follow
-[shadcn.md](references/shadcn.md). Without it, hand-build components against Tailwind and
-the `cn()` helper.
+Treat shadcn/ui as an optional component-library layer. Do not initialize it unless the
+project already uses it or the user chooses it.
 
-## Environment Setup
+## Guardrails
 
-Use [asdf](https://asdf-vm.com/) to manage Bun:
+1. Inspect the repository before changing dependencies or configuration.
+2. Preserve its package manager, framework, routing mode, component system, and quality
+   tools unless the user explicitly requests a migration.
+3. Use `bun add` in Bun projects; do not hand-edit dependency versions or regenerate a
+   lockfile with another package manager.
+4. Pin React Router to the supported major with `bun add react-router@7`; an unqualified
+   install can move the project to a later major.
+5. Keep URL state shareable and preserve unrelated query parameters when updating it.
+6. Never commit, push, or publish unless the user has authorized that action.
 
-```bash
-# Install the Bun plugin (one-time)
-asdf plugin add bun
+## Choose the Relevant Reference
 
-# Pin Bun for the project (writes .tool-versions)
-asdf set bun latest
-asdf install
-```
+| Task | Reference |
+|------|-----------|
+| Bootstrap the base stack | [setup-guide.md](references/setup-guide.md) |
+| Apply routing, URL-state, layout, and accessibility patterns | [patterns.md](references/patterns.md) |
+| Add or maintain shadcn/ui | [shadcn.md](references/shadcn.md) |
+| Add or debug MapLibre GL JS | [maplibre.md](references/maplibre.md) |
+| Research library APIs and components | [mcp-tools.md](references/mcp-tools.md) |
 
-## Reference Files
+Read only the references needed for the task. For a new project, start with the setup
+guide, then open the patterns guide. Open the shadcn or MapLibre reference only when that
+layer is in scope.
 
-| File | When to Use |
-|------|-------------|
-| [setup-guide.md](references/setup-guide.md) | Starting a new project from scratch (base stack) |
-| [patterns.md](references/patterns.md) | Routing, state, layout, and component patterns |
-| [shadcn.md](references/shadcn.md) | **Optional** — adding the shadcn/ui component library |
-| [maplibre.md](references/maplibre.md) | Working with MapLibre GL JS maps |
-| [mcp-tools.md](references/mcp-tools.md) | Looking up docs (context7) and shadcn components via MCP |
+## Base Conventions
 
-## Quick Reference
-
-### Commands
-
-```bash
-# Dev server
-bun run dev          # → vite
-
-# Production build
-bun run build        # → tsc -b && vite build
-
-# Type check
-bun run typecheck    # → tsc --noEmit
-```
-
-### Package Management
-
-Use **Bun** for all dependency management — never edit `package.json` by hand:
-
-```bash
-bun add react-router clsx tailwind-merge      # runtime deps
-bun add -d @types/node                        # dev deps
-```
-
-`bun add` resolves the latest compatible version and keeps `bun.lock` in sync. Commit
-`bun.lock`.
-
-### Key Imports
+### Imports
 
 ```typescript
-// React Router v7 - use 'react-router' NOT 'react-router-dom'
-import { Routes, Route, Link, useLocation, useSearchParams } from 'react-router'
-
-// Path alias - @/ maps to src/
+import { NavLink, Route, Routes, useSearchParams } from 'react-router'
 import { cn } from '@/lib/utils'
 ```
 
-### The cn() helper
+Use `react-router`, not `react-router-dom`, for this v7 stack. Follow an existing
+repository's established router mode rather than replacing it automatically.
+
+### Class composition
 
 ```typescript
-// src/lib/utils.ts
 import { clsx, type ClassValue } from 'clsx'
 import { twMerge } from 'tailwind-merge'
 
@@ -92,89 +65,67 @@ export function cn(...inputs: ClassValue[]) {
 }
 ```
 
-### Conditional Classes
+### Semantic styling
 
-```typescript
-import { cn } from '@/lib/utils'
+Base-stack examples use tokens such as `bg-background`, `text-foreground`, `bg-muted`,
+and `text-muted-foreground`. Define those tokens in `src/index.css` as shown in the setup
+guide. Do not assume shadcn has created them.
 
-<div className={cn(
-  "base-classes",
-  condition && "conditional-classes",
-  variant === "primary" && "variant-classes"
-)} />
-```
+## Quality Baseline
 
-### Project Structure
+For every UI change:
 
-```
-src/
-├── components/       # Shared UI components (add components/ui/ if using shadcn)
-│   ├── AppShell.tsx  # Main layout with header
-│   └── AppSidebar.tsx
-├── pages/            # Route page components
-├── hooks/            # Custom hooks
-├── lib/
-│   └── utils.ts      # cn() helper
-├── App.tsx           # Route definitions
-├── main.tsx          # Entry point with BrowserRouter
-└── index.css         # Tailwind import (+ theme variables)
-```
+- Use semantic elements and programmatic labels.
+- Preserve keyboard operation and visible focus indicators.
+- Do not convey status by color alone.
+- Cover loading, empty, error, disabled, and success states that apply.
+- Check narrow and wide layouts and respect reduced-motion preferences.
+- Use `NavLink` or router matching for active navigation instead of exact pathname
+  equality when nested routes should remain active.
+- Put shareable filters, selections, and pagination in the URL; update a copy of the
+  current `URLSearchParams` so unrelated parameters survive.
 
-### Tailwind Patterns
+## Code Quality Contract
 
-```typescript
-// Common utility patterns
-"flex items-center gap-4"           // Flexbox with gap
-"bg-muted text-muted-foreground"    // Muted backgrounds
-"border-b bg-background"            // Borders and backgrounds
-"h-screen overflow-auto"            // Full height scrolling
-"space-y-4"                         // Vertical spacing
-```
-
-### Common Gotchas
-
-- **Package management**: Use `bun add <pkg>` not manual `package.json` edits
-- **React Router imports**: Use `react-router` NOT `react-router-dom`
-- **shadcn is optional**: Only reach for `components/ui/` + `bunx shadcn@latest` when the
-  project has opted into shadcn/ui (see [shadcn.md](references/shadcn.md)); otherwise build
-  components by hand with Tailwind + `cn()`
-
-## CI & Code Quality
-
-Lint, format, and type-check are part of the stack, not an afterthought — wire them into
-CI from the start. The cross-cutting setup (asdf provisioning + caching, path-filtered
-workflows, lockfile-frozen installs, the GitHub Actions templates) lives in the
-**`ci-quality-gates`** skill; this section is just the React-stack specifics that plug into it.
-
-**Linter + formatter: oxc, not eslint/prettier.** A fresh Vite scaffold ships an eslint
-config — **remove it** and adopt **oxlint + oxfmt** (the Jarvus standard). Don't run both.
+Jarvus TypeScript packages use oxc rather than ESLint and Prettier. Remove scaffolded
+ESLint only when adopting this contract, then install:
 
 ```bash
 bun add -d oxlint oxfmt
 ```
 
-**The script contract.** Expose the same four scripts every Jarvus TS package does, so CI
-just calls `bun run <name>`:
+Expose these scripts so local and CI commands agree:
 
 ```jsonc
 {
   "scripts": {
-    "dev":          "vite",
-    "build":        "tsc -b && vite build",
-    "typecheck":    "tsc --noEmit",
-    "lint":         "oxlint .",
-    "format":       "oxfmt .",
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "typecheck": "tsc --noEmit",
+    "lint": "oxlint .",
+    "format": "oxfmt .",
     "format:check": "oxfmt --check ."
   }
 }
 ```
 
-A React app's `.oxlintrc.json` uses the **stricter React config** (suspicious + perf
-categories, react-hooks, react-compiler) — copy `references/templates/oxlintrc.react.json`
-from `ci-quality-gates`. Commit `.vscode/extensions.json` recommending `oxc.oxc-vscode` so
-format-on-save matches CI.
+Use the stricter React config and `ui-checks.yml` from the `ci-quality-gates` skill. That
+workflow also expects a `test` script: configure the repository's chosen test runner
+before enabling the test step, or deliberately adapt the workflow. Do not add a fake or
+no-op test command merely to make CI green.
 
-**CI workflow.** Use the single-package `ui-checks.yml` template from `ci-quality-gates` —
-one job running `bun run lint`, `format:check`, and `typecheck`, provisioned by the shared
-`setup-asdf` composite. See that skill for the full build order and the one-time migration
-when turning the gate on for an existing app.
+## Completion Checks
+
+Run the repository's relevant scripts, normally:
+
+```bash
+bun run lint
+bun run format:check
+bun run typecheck
+bun run test
+bun run build
+```
+
+Skip only commands that genuinely are not configured, and report that limitation. Check
+the final diff for unintended dependency, lockfile, generated-file, and formatting
+changes.

--- a/skills/jarvus-react/references/mcp-tools.md
+++ b/skills/jarvus-react/references/mcp-tools.md
@@ -1,116 +1,52 @@
-# MCP Tools for Frontend Development
+# Documentation and Component Research
 
-Two MCP servers enhance frontend development workflows: **shadcn** for UI components (only
-relevant if you've adopted the optional shadcn layer — see [shadcn.md](shadcn.md)) and
-**context7** for library documentation.
+Use the documentation and component-discovery tools available in the current agent
+environment. Tool names and providers vary, so do not assume a particular MCP server is
+installed or hard-code one provider's invocation syntax into the workflow.
 
-> **Note:** If these MCP servers are configured in your Claude Code setup, they'll be
-> available automatically. The shadcn tools below apply only when the project uses shadcn/ui.
+## Research Order
 
-## Research Workflow
+1. Inspect the repository's installed versions, lockfile, configuration, and existing
+   patterns.
+2. Use local type definitions or package documentation when they answer the question.
+3. Use an available documentation tool or the library's official documentation for
+   version-specific behavior.
+4. If the project uses shadcn/ui, use an available registry tool or the official shadcn
+   registry to find components and examples.
+5. Install only after confirming the package, supported major, and integration steps.
 
-Before implementing new features or installing unfamiliar libraries:
+This order prevents current documentation from being applied blindly to an older installed
+major and avoids adding dependencies when the repository already has an equivalent.
 
-1. **Research** with context7 MCP - Get up-to-date documentation
-2. **Understand** with shadcn MCP - Find component examples
-3. **Install** with `bun add` / `bunx` - Add the dependency
-4. **Implement** - Build the feature
+## Library Documentation
 
-## shadcn MCP Server
+Ask narrow questions that include the installed major and the relevant routing or build
+mode. Examples:
 
-Use for discovering, understanding, and installing shadcn/ui components.
+- "React Router v7 declarative mode: how does `NavLink` match nested routes?"
+- "Tailwind CSS v4 with `@tailwindcss/vite`: how are custom color tokens declared?"
+- "MapLibre GL JS installed version: what cleanup does a map instance require?"
 
-### Search for Components
+Prefer primary sources. Confirm generated examples use the package names and APIs already
+present in the repository before copying them.
 
-```
-mcp__shadcn__search_items_in_registries(registries: ["@shadcn"], query: "sidebar")
-```
+## shadcn/ui Discovery
 
-Common searches: `sidebar`, `card`, `dialog`, `dropdown`, `table`, `form`, `button`
+Only search the shadcn registry after confirming the project has adopted shadcn/ui or the
+user wants to add it. Then:
 
-### Get Component Examples
+1. Search the registry for the behavior, not just a component name.
+2. Inspect component source and usage examples.
+3. Get or construct the exact `bunx --bun shadcn@latest add ...` command.
+4. Review the generated diff, including dependencies, `components.json`, theme variables,
+   and any overwritten utilities.
+5. Run the project's quality checks.
 
-```
-mcp__shadcn__get_item_examples_from_registries(registries: ["@shadcn"], query: "button-demo")
-```
+Do not treat registry output as a dependency-free snippet: shadcn components are copied
+source that the repository owns after installation.
 
-Pattern: Use `{component}-demo` to find usage examples.
+## If No Research Tool Is Available
 
-### Get Install Command
-
-```
-mcp__shadcn__get_add_command_for_items(items: ["@shadcn/sidebar"])
-```
-
-Returns the exact shadcn add command (run it with `bunx --bun shadcn@latest add ...`).
-
-### Workflow Example
-
-```
-1. mcp__shadcn__search_items_in_registries(registries: ["@shadcn"], query: "data table")
-2. mcp__shadcn__get_item_examples_from_registries(registries: ["@shadcn"], query: "data-table-demo")
-3. mcp__shadcn__get_add_command_for_items(items: ["@shadcn/table"])
-4. Run: bunx --bun shadcn@latest add table -y
-```
-
-### After Adding Components
-
-Use `mcp__shadcn__get_audit_checklist` to verify the component was added correctly and understand any additional setup needed.
-
-## context7 MCP Server
-
-Use for accessing up-to-date documentation for React, TypeScript, and other libraries.
-
-### Resolve Library ID
-
-First, get the context7 library ID:
-
-```
-mcp__context7__resolve-library-id(libraryName: "react-router", query: "routing")
-```
-
-Returns: `/remix-run/react-router`
-
-### Query Library Docs
-
-Then fetch specific documentation:
-
-```
-mcp__context7__query-docs(
-  libraryId: "/remix-run/react-router",
-  query: "useSearchParams hook usage"
-)
-```
-
-### Common Libraries
-
-| Library | context7 ID | Common Topics |
-|---------|-------------|---------------|
-| React Router v7 | `/remix-run/react-router` | BrowserRouter, useLocation, useSearchParams |
-| React | `/facebook/react` | hooks, context, suspense |
-| Tailwind CSS | `/tailwindlabs/tailwindcss` | utilities, configuration |
-| MapLibre GL | `/maplibre/maplibre-gl-js` | Map, markers, layers |
-
-### Workflow Example
-
-```
-1. mcp__context7__resolve-library-id(libraryName: "react-router", query: "routing")
-   → Returns: /remix-run/react-router
-
-2. mcp__context7__query-docs(
-     libraryId: "/remix-run/react-router",
-     query: "nested routes configuration"
-   )
-   → Returns: Documentation on nested routing patterns
-```
-
-## When to Use Each
-
-| Scenario | Tool |
-|----------|------|
-| Adding a new UI component | shadcn MCP |
-| Understanding component API | shadcn MCP (examples) |
-| Learning React Router patterns | context7 MCP |
-| Checking latest library syntax | context7 MCP |
-| Finding component install command | shadcn MCP |
-| Debugging library behavior | context7 MCP (mode: "info") |
+Use installed source and official documentation. If network access is unavailable, state
+which version-specific point remains unverified rather than guessing. A missing MCP server
+is not a reason to block ordinary local implementation work.

--- a/skills/jarvus-react/references/patterns.md
+++ b/skills/jarvus-react/references/patterns.md
@@ -1,49 +1,51 @@
 # Development Patterns
 
-Patterns for building features in Bun + Vite + React + Tailwind + React Router v7 projects.
-The routing, state, and layout patterns here are stack-agnostic. Examples that import from
-`@/components/ui/*` assume the **optional** shadcn/ui layer (see [shadcn.md](shadcn.md)); the
-base-stack equivalents (hand-built with Tailwind + `cn()`) are in
-[setup-guide.md](setup-guide.md).
+Base-stack patterns for Bun, Vite, React, Tailwind CSS, and React Router v7. These examples
+do not require shadcn/ui. For shadcn components and its sidebar layout, use
+[shadcn.md](shadcn.md).
+
+## Contents
+
+- [Project Structure](#project-structure)
+- [Routing Architecture](#routing-architecture)
+- [URL State](#url-state)
+- [Component and Page Design](#component-and-page-design)
+- [Accessibility and Responsive Quality](#accessibility-and-responsive-quality)
+- [Verification](#verification)
 
 ## Project Structure
 
-```
+```text
 src/
-├── components/
-│   ├── ui/              # shadcn/ui components — only if you adopted shadcn (see shadcn.md)
-│   ├── AppShell.tsx     # Main layout with header and outlet
-│   └── AppSidebar.tsx   # Navigation sidebar
-├── pages/               # Route page components (organized by feature)
-│   ├── dashboard/
-│   └── settings/
-├── hooks/               # Custom React hooks
+├── components/       # Shared application components
+│   └── AppShell.tsx
+├── hooks/            # Custom React hooks
 ├── lib/
-│   └── utils.ts         # cn() helper and shared utilities
-├── App.tsx              # Route definitions
-├── main.tsx             # Entry point with BrowserRouter
-└── index.css            # Tailwind import (+ theme variables)
+│   └── utils.ts      # cn() and shared utilities
+├── pages/            # Route components grouped by feature
+├── App.tsx           # Route definitions
+├── main.tsx          # Entry point and BrowserRouter
+└── index.css         # Tailwind import and theme tokens
 ```
 
-**Conventions:**
-
-- Use `pages/` directory for page components organized by feature area
-- Utility functions go in `lib/` directory
-- Path alias `@/*` maps to `./src/*`
-- Build components by hand with Tailwind + `cn()`; reach for shadcn/ui (`components/ui/`)
-  only when the project has opted into it
+- Keep route-level components in `pages/` and reusable UI in `components/`.
+- Put non-React helpers in `lib/` and reusable hooks in `hooks/`.
+- Use the `@/*` alias only after it is configured in Vite and the tsconfig that covers
+  `src/`.
+- Add `components/ui/` only if the project adopts shadcn/ui.
 
 ## Routing Architecture
 
-### React Router v7 Setup
+Follow the router mode already present in the repository. A small browser-routed app can
+use declarative routing:
 
-```typescript
-// main.tsx - Entry point
+```tsx
+// main.tsx
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { BrowserRouter } from 'react-router'
-import './index.css'
 import App from './App'
+import './index.css'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
@@ -54,22 +56,18 @@ createRoot(document.getElementById('root')!).render(
 )
 ```
 
-```typescript
-// App.tsx - Route definitions
-import { Routes, Route } from 'react-router'
-import { SidebarProvider } from '@/components/ui/sidebar'
-import { AppSidebar } from '@/components/AppSidebar'
-import { AppShell } from '@/components/AppShell'
+Use a layout route and `<Outlet />` instead of repeating application chrome:
 
-function App() {
+```tsx
+import { Route, Routes } from 'react-router'
+import { AppShell } from '@/components/AppShell'
+import { DashboardPage } from '@/pages/dashboard/DashboardPage'
+import { SettingsPage } from '@/pages/settings/SettingsPage'
+
+export default function App() {
   return (
     <Routes>
-      <Route path="/" element={
-        <SidebarProvider>
-          <AppSidebar />
-          <AppShell />
-        </SidebarProvider>
-      }>
+      <Route path="/" element={<AppShell />}>
         <Route index element={<DashboardPage />} />
         <Route path="settings" element={<SettingsPage />} />
       </Route>
@@ -78,241 +76,109 @@ function App() {
 }
 ```
 
-### Key Imports
+Use `NavLink` for navigation state. `end` keeps the root link from matching every nested
+route:
 
-All routing imports come from `react-router` (NOT `react-router-dom`):
+```tsx
+import { NavLink } from 'react-router'
+import { cn } from '@/lib/utils'
 
-```typescript
-import {
-  BrowserRouter,    // Wrap app in main.tsx
-  Routes, Route,    // Define routes in App.tsx
-  Link,             // Navigation links
-  Outlet,           // Render child routes
-  useLocation,      // Get current path
-  useParams,        // Get route params
-  useSearchParams,  // Get/set query params
-} from 'react-router'
+<NavLink
+  to="/"
+  end
+  className={({ isActive }) =>
+    cn(
+      'rounded px-3 py-2 focus-visible:outline-2 focus-visible:outline-offset-2',
+      isActive ? 'bg-muted font-medium' : 'text-muted-foreground hover:bg-muted',
+    )
+  }
+>
+  Dashboard
+</NavLink>
 ```
 
-### Nested Routes with Outlet
+Import v7 APIs from `react-router`, not `react-router-dom`. Prefer router matching APIs
+over manual exact comparisons with `location.pathname`, especially for nested routes.
 
-```typescript
-// Parent route renders layout + Outlet
-<Route path="/" element={<Layout />}>
-  {/* Child routes render into Outlet */}
-  <Route index element={<Home />} />
-  <Route path="about" element={<About />} />
-</Route>
-```
+## URL State
 
-## State Management
+Put state in the URL when users should be able to bookmark, refresh, or share it. Typical
+examples are search terms, filters, sorting, pagination, and the selected tab.
 
-### URL-Based State
+Read and validate values before using them:
 
-Use `useSearchParams` for state that should persist in the URL:
-
-```typescript
+```tsx
 const [searchParams, setSearchParams] = useSearchParams()
-
-// Read value
-const environment = searchParams.get('env')
-
-// Update value
-setSearchParams({ env: 'production' })
+const environment = searchParams.get('env') ?? 'all'
+const page = Math.max(1, Number(searchParams.get('page')) || 1)
 ```
 
-### Route-Based Logic
+When updating one parameter, copy the current params so unrelated state survives:
 
-Use `useLocation` for determining active states:
+```tsx
+function setEnvironment(environment: string) {
+  setSearchParams((current) => {
+    const next = new URLSearchParams(current)
 
-```typescript
-const location = useLocation()
-const isActive = location.pathname === '/dashboard'
-```
+    if (environment === 'all') {
+      next.delete('env')
+    } else {
+      next.set('env', environment)
+    }
 
-### Query Parameter Preservation
-
-Create a helper to preserve query params across navigation:
-
-```typescript
-function createNavLink(path: string, searchParams: URLSearchParams) {
-  const params = searchParams.toString()
-  return params ? `${path}?${params}` : path
+    next.delete('page') // the filter changed, so reset dependent pagination
+    return next
+  })
 }
 ```
 
-## Component Patterns
+Avoid `setSearchParams({ env: 'production' })` when other parameters may exist: replacing
+the whole query string can silently discard them.
 
-### Layout System
+## Component and Page Design
 
-> The `AppSidebar` example below imports shadcn/ui's `sidebar` component — it assumes the
-> optional shadcn layer ([shadcn.md](shadcn.md)). For a base-stack layout without shadcn,
-> see the hand-built `AppShell` in [setup-guide.md](setup-guide.md).
+Keep pages responsible for feature composition and components responsible for reusable
+behavior. A page should expose a useful heading hierarchy and explicit UI states:
 
-**AppShell** - Main content wrapper with header:
+```tsx
+export function ResultsPage() {
+  const query = useResults()
 
-```typescript
-import { Outlet } from 'react-router'
-import { SidebarTrigger } from '@/components/ui/sidebar'
+  if (query.isPending) return <p role="status">Loading results…</p>
+  if (query.isError) return <p role="alert">Could not load results.</p>
+  if (query.data.length === 0) return <p>No results match these filters.</p>
 
-export function AppShell() {
   return (
-    <div className="flex-1 flex flex-col h-screen bg-background">
-      <header className="flex h-14 items-center gap-4 border-b bg-background px-4 lg:px-6">
-        <SidebarTrigger />
-        <div className="flex-1" />
-      </header>
-      <main className="flex-1 overflow-auto">
-        <Outlet />
-      </main>
-    </div>
+    <section aria-labelledby="results-heading" className="space-y-4 p-4 sm:p-6">
+      <h1 id="results-heading" className="text-2xl font-semibold">Results</h1>
+      <ResultsList results={query.data} />
+    </section>
   )
 }
 ```
 
-**AppSidebar** - Navigation with active states:
+For status styles, pair color with text, an icon, or another programmatic cue. Do not make
+red, amber, or green the only way to understand a state.
 
-```typescript
-import { useLocation, Link } from 'react-router'
-import {
-  Sidebar, SidebarContent, SidebarGroup,
-  SidebarGroupContent, SidebarGroupLabel, SidebarHeader,
-  SidebarMenu, SidebarMenuButton, SidebarMenuItem,
-} from '@/components/ui/sidebar'
+## Accessibility and Responsive Quality
 
-export function AppSidebar() {
-  const location = useLocation()
+- Prefer native `button`, `a`, `nav`, `main`, `form`, and heading elements.
+- Give every control an accessible name; use a visible `<label>` when practical.
+- Keep focus visible and verify the interface with a keyboard alone.
+- Use ARIA only to fill a semantic gap, not to replace native behavior.
+- Provide loading, empty, error, disabled, and success feedback where each applies.
+- Start with narrow layouts, then add `sm:`, `md:`, or `lg:` changes when content needs
+  them; avoid breakpoint-driven complexity without a layout reason.
+- Respect `prefers-reduced-motion` with Tailwind's `motion-reduce:` utilities when adding
+  nonessential transitions or animation.
+- Avoid assuming light or dark mode exists. Use the project's defined semantic tokens.
 
-  return (
-    <Sidebar>
-      <SidebarHeader className="border-b px-4 py-4">
-        <span className="font-semibold">App Name</span>
-      </SidebarHeader>
-      <SidebarContent>
-        <SidebarGroup>
-          <SidebarGroupLabel>Navigation</SidebarGroupLabel>
-          <SidebarGroupContent>
-            <SidebarMenu>
-              <SidebarMenuItem>
-                <SidebarMenuButton asChild isActive={location.pathname === '/'}>
-                  <Link to="/">
-                    <Home className="mr-2 h-4 w-4" />
-                    Dashboard
-                  </Link>
-                </SidebarMenuButton>
-              </SidebarMenuItem>
-            </SidebarMenu>
-          </SidebarGroupContent>
-        </SidebarGroup>
-      </SidebarContent>
-    </Sidebar>
-  )
-}
-```
+## Verification
 
-### Page Components
-
-Consistent structure with header and content sections:
-
-```typescript
-export function DashboardPage() {
-  return (
-    <div className="p-6 space-y-6">
-      <div>
-        <h1 className="text-2xl font-semibold">Dashboard</h1>
-        <p className="text-muted-foreground">Overview of your data</p>
-      </div>
-
-      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-        {/* Content cards */}
-      </div>
-    </div>
-  )
-}
-```
-
-### Collapsible Sidebar Sections
-
-```typescript
-import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible'
-import { ChevronDown } from 'lucide-react'
-
-<Collapsible defaultOpen className="group/collapsible">
-  <SidebarMenuItem>
-    <CollapsibleTrigger asChild>
-      <SidebarMenuButton>
-        <FolderIcon className="mr-2 h-4 w-4" />
-        Section
-        <ChevronDown className="ml-auto h-4 w-4 transition-transform group-data-[state=open]/collapsible:rotate-180" />
-      </SidebarMenuButton>
-    </CollapsibleTrigger>
-    <CollapsibleContent>
-      <SidebarMenuSub>
-        {/* Sub items */}
-      </SidebarMenuSub>
-    </CollapsibleContent>
-  </SidebarMenuItem>
-</Collapsible>
-```
-
-## UI Patterns
-
-### Common Layouts
-
-- **Two-column layouts** for complex forms
-- **Card-based layouts** for dashboards and listings
-- **Consistent navigation** with back links and breadcrumbs
-
-### Design Conventions
-
-**shadcn/ui components:**
-
-- Button, Input, Badge, Card, Tabs
-- Sidebar, Dialog, Command, Table
-- Tooltip, Dropdown Menu, Select
-
-**Tailwind patterns:**
-
-- `bg-muted`, `text-muted-foreground` - Muted backgrounds/text
-- `space-y-4`, `gap-4` - Consistent spacing
-- `flex-1` - Flexible sizing
-- `border-b`, `border-r` - Borders
-
-### Color-Coded Status
-
-```typescript
-// Status badges with semantic colors
-<Badge variant="default">Active</Badge>      // Primary color
-<Badge variant="secondary">Pending</Badge>   // Muted
-<Badge variant="destructive">Error</Badge>   // Red
-<Badge variant="outline">Draft</Badge>       // Outlined
-```
-
-## Development Workflow
-
-### Before Starting Dev Server
-
-Check if a dev server is already running on port 5173:
-
-```bash
-lsof -i :5173
-```
-
-### Testing Changes
-
-1. Run the dev server and verify navigation works
-2. Ensure query parameter preservation across route transitions
-3. Verify active states for all sidebar menu items
-4. Check conditional rendering for context-dependent sections
-
-### Package Management
-
-- Always use `bun add <package-name>` to add dependencies
-- Never manually edit `package.json` to add packages
-- If using shadcn/ui, add components with `bunx --bun shadcn@latest add <component> -y`
-
-### Theming Considerations
-
-- Project typically uses light theme only (configure dark mode if needed)
-- CSS variables defined in `index.css` control theme colors
-- Avoid adding `dark:` classes unless dark mode is implemented
+1. Exercise every changed route directly and through navigation.
+2. Refresh and share URLs containing filters or pagination; confirm state is restored.
+3. Update one query parameter and confirm unrelated parameters remain.
+4. Check keyboard order, visible focus, labels, and status announcements.
+5. Check loading, empty, error, disabled, and success states that apply.
+6. Test a narrow viewport, a wide viewport, and reduced motion.
+7. Run the repository's lint, format check, typecheck, tests, and production build.

--- a/skills/jarvus-react/references/setup-guide.md
+++ b/skills/jarvus-react/references/setup-guide.md
@@ -4,6 +4,15 @@ This guide bootstraps the React base stack on **Bun** — Bun is the runtime, pa
 and script runner; Vite is the build tool and dev server. shadcn/ui is **optional**; when you
 want it, layer it on afterward via [shadcn.md](shadcn.md).
 
+## Contents
+
+- [Prerequisites](#prerequisites)
+- [Step-by-Step Setup](#step-by-step-setup)
+- [File Structure After Setup](#file-structure-after-setup)
+- [package.json Scripts](#packagejson-scripts)
+- [VSCode Debugging](#vscode-debugging)
+- [Common Issues](#common-issues)
+
 ## Prerequisites
 
 - Bun (latest)
@@ -32,9 +41,9 @@ bun create vite . --template react-ts
 bun install
 ```
 
-This creates the base React 19 + TypeScript project with Vite 7.x.
-
-**Commit:** `feat: initialize Vite project with React + TypeScript`
+This creates the current React + TypeScript Vite template. Review the generated dependency
+versions and commit the resulting `bun.lock`; do not rely on this guide for a Vite minor
+version.
 
 ---
 
@@ -45,8 +54,6 @@ bun add tailwindcss @tailwindcss/vite
 ```
 
 **Note:** Tailwind v4 uses the `@tailwindcss/vite` plugin instead of a PostCSS config.
-
-**Commit:** `build: install Tailwind CSS with @tailwindcss/vite plugin`
 
 ---
 
@@ -76,10 +83,25 @@ export default defineConfig({
 })
 ```
 
-**Update `src/index.css`** (replace all content):
+**Update `src/index.css`** (replace all content). The theme tokens make the base examples
+work without shadcn/ui:
 
 ```css
 @import "tailwindcss";
+
+@theme {
+  --color-background: oklch(1 0 0);
+  --color-foreground: oklch(0.145 0 0);
+  --color-muted: oklch(0.97 0 0);
+  --color-muted-foreground: oklch(0.556 0 0);
+  --color-border: oklch(0.922 0 0);
+}
+
+@layer base {
+  body {
+    @apply bg-background text-foreground;
+  }
+}
 ```
 
 **Add the `@/*` path alias** to `tsconfig.json` (and `tsconfig.app.json` if Vite split the
@@ -95,8 +117,6 @@ config). The alias must be present in whichever tsconfig covers `src/`:
   }
 }
 ```
-
-**Commit:** `config: configure Tailwind CSS and TypeScript path aliases`
 
 ---
 
@@ -120,8 +140,6 @@ export function cn(...inputs: ClassValue[]) {
 }
 ```
 
-**Commit:** `feat: add cn() class-merging helper`
-
 ---
 
 ### 5. Install React Router v7
@@ -129,10 +147,11 @@ export function cn(...inputs: ClassValue[]) {
 **IMPORTANT:** React Router v7 uses the package name `react-router`, NOT `react-router-dom`.
 
 ```bash
-bun add react-router
+bun add react-router@7
 ```
 
-**Commit:** `build: install React Router v7`
+Pin the supported major explicitly. An unqualified install may select a newer major with a
+different contract.
 
 ---
 
@@ -192,7 +211,7 @@ and an `<Outlet />`; child routes render inside it.
 **`src/components/AppShell.tsx`:**
 
 ```tsx
-import { Outlet, Link, useLocation } from 'react-router'
+import { NavLink, Outlet } from 'react-router'
 import { cn } from '@/lib/utils'
 
 const nav = [
@@ -201,25 +220,27 @@ const nav = [
 ]
 
 export function AppShell() {
-  const location = useLocation()
   return (
     <div className="flex h-screen flex-col bg-background">
       <header className="flex h-14 items-center gap-4 border-b px-4 lg:px-6">
         <span className="font-semibold">App Name</span>
         <nav className="flex gap-2">
           {nav.map((item) => (
-            <Link
+            <NavLink
               key={item.to}
               to={item.to}
-              className={cn(
-                "rounded px-3 py-1.5 text-sm",
-                location.pathname === item.to
-                  ? "bg-muted font-medium"
-                  : "text-muted-foreground hover:bg-muted",
-              )}
+              end={item.to === '/'}
+              className={({ isActive }) =>
+                cn(
+                  "rounded px-3 py-1.5 text-sm focus-visible:outline-2 focus-visible:outline-offset-2",
+                  isActive
+                    ? "bg-muted font-medium"
+                    : "text-muted-foreground hover:bg-muted",
+                )
+              }
             >
               {item.label}
-            </Link>
+            </NavLink>
           ))}
         </nav>
       </header>
@@ -252,8 +273,6 @@ function App() {
 > Want a richer, accessible sidebar instead of this hand-built nav? Adopt shadcn/ui and use
 > its `sidebar` component — see [shadcn.md](shadcn.md).
 
-**Commit:** `feat: add app shell layout`
-
 ---
 
 ### 8. Optional: shadcn/ui Component Library
@@ -272,8 +291,6 @@ bun add maplibre-gl
 
 See [maplibre.md](maplibre.md) for a map component. (Remember to import the CSS for proper
 styling.)
-
-**Commit:** `build: install MapLibre GL JS`
 
 ---
 
@@ -301,18 +318,30 @@ styling.)
 
 ## package.json Scripts
 
-```json
+Remove the scaffolded ESLint files only when adopting the Jarvus oxc contract, then
+install its tools:
+
+```bash
+bun add -d oxlint oxfmt
+```
+
+```jsonc
 {
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
     "typecheck": "tsc --noEmit",
+    "lint": "oxlint .",
+    "format": "oxfmt .",
+    "format:check": "oxfmt --check .",
     "preview": "vite preview"
   }
 }
 ```
 
-Run them with Bun: `bun run dev`, `bun run build`, `bun run typecheck`.
+The `ui-checks.yml` template from `ci-quality-gates` also invokes `bun run test`. Configure
+the project's chosen test runner and add a real `test` script before enabling that step,
+or deliberately adapt the workflow. Never add a no-op test command.
 
 ---
 
@@ -344,8 +373,6 @@ For client-side React debugging, launch Chrome against the Vite dev server.
 
 The default Vite port is `5173`; `webRoot` maps to `src/` for accurate source-map resolution.
 
-**Commit:** `config: add VSCode debugging configuration`
-
 ---
 
 ## Common Issues
@@ -365,4 +392,5 @@ Use `react-router` not `react-router-dom` for v7.
 
 ### Tailwind Classes Not Working
 
-Ensure `@import "tailwindcss";` is at the top of `index.css`.
+Ensure `@import "tailwindcss";` is at the top of `index.css` and that every semantic class
+used by the app has a corresponding token in `@theme`.

--- a/skills/jarvus-react/references/shadcn.md
+++ b/skills/jarvus-react/references/shadcn.md
@@ -9,6 +9,15 @@ when hand-built Tailwind components are enough.
 Prerequisites: the base stack from [setup-guide.md](setup-guide.md) — Vite + React +
 Tailwind v4 + the `@/` path alias + the `cn()` helper.
 
+## Contents
+
+- [Initialize shadcn/ui](#1-initialize-shadcnui)
+- [Add Components](#2-add-components)
+- [App Shell with the shadcn Sidebar](#3-app-shell-with-the-shadcn-sidebar)
+- [Collapsible Sidebar Sections](#collapsible-sidebar-sections)
+- [Status with Badge](#status-with-badge)
+- [Common Issues](#common-issues)
+
 ## 1. Initialize shadcn/ui
 
 shadcn's CLI detects Bun and uses it. Run it with `bunx`:
@@ -30,8 +39,6 @@ This will:
 - Base color: Neutral (or your preference)
 - CSS variables: Yes
 
-**Commit:** `feat: initialize shadcn/ui with Neutral color scheme`
-
 ## 2. Add Components
 
 Add components as needed — the CLI copies their source into `components/ui/`:
@@ -42,7 +49,8 @@ bunx --bun shadcn@latest add card button collapsible -y
 ```
 
 The `sidebar` component pulls in several dependencies automatically (button, separator,
-sheet, tooltip, input, skeleton). Commit each addition (or batch related ones).
+sheet, tooltip, input, skeleton). Review the generated source and dependency diff before
+continuing.
 
 Common components:
 
@@ -50,7 +58,8 @@ Common components:
 bunx --bun shadcn@latest add button card sidebar collapsible dropdown-menu avatar separator sheet tooltip input skeleton badge tabs dialog alert
 ```
 
-Use the bundled shadcn MCP server to search components and get exact add commands — see
+Use an available registry tool or the official shadcn registry to search components and
+confirm exact add commands — see
 [mcp-tools.md](mcp-tools.md).
 
 ## 3. App Shell with the shadcn Sidebar
@@ -81,7 +90,7 @@ export function AppShell() {
 **`src/components/AppSidebar.tsx`:**
 
 ```tsx
-import { useLocation, Link } from 'react-router'
+import { Link, useMatch } from 'react-router'
 import {
   Sidebar, SidebarContent, SidebarGroup,
   SidebarGroupContent, SidebarGroupLabel, SidebarHeader,
@@ -90,7 +99,7 @@ import {
 import { Home } from 'lucide-react'
 
 export function AppSidebar() {
-  const location = useLocation()
+  const isHome = useMatch({ path: '/', end: true })
 
   return (
     <Sidebar>
@@ -103,7 +112,7 @@ export function AppSidebar() {
           <SidebarGroupContent>
             <SidebarMenu>
               <SidebarMenuItem>
-                <SidebarMenuButton asChild isActive={location.pathname === '/'}>
+                <SidebarMenuButton asChild isActive={Boolean(isHome)}>
                   <Link to="/">
                     <Home className="mr-2 h-4 w-4" />
                     Home
@@ -168,7 +177,7 @@ import { ChevronDown } from 'lucide-react'
 </Collapsible>
 ```
 
-## Color-Coded Status with Badge
+## Status with Badge
 
 ```tsx
 <Badge variant="default">Active</Badge>      // Primary color
@@ -176,6 +185,8 @@ import { ChevronDown } from 'lucide-react'
 <Badge variant="destructive">Error</Badge>   // Red
 <Badge variant="outline">Draft</Badge>       // Outlined
 ```
+
+Keep the status text or another programmatic cue; color alone must not carry the meaning.
 
 ## Common Issues
 


### PR DESCRIPTION
## What changed

- narrow skill activation to repositories already using the Jarvus stack or explicit bootstrap/migration requests
- pin React Router v7 and remove the stale Vite minor-version claim
- make the non-shadcn setup complete by defining its semantic Tailwind theme tokens
- align setup scripts and guidance with the oxc and `ui-checks.yml` contract
- replace fragile pathname and query-string examples with router matching and parameter-preserving updates
- separate base patterns from optional shadcn examples and add a compact accessibility/responsive quality baseline
- make documentation research provider-neutral instead of assuming Claude-specific MCP tool names
- remove agent-directed commit instructions and reduce the skill by 207 net lines

## Why a separate PR

PR #39 is a focused MapLibre lifecycle and failure-mode reference. This broader contract and progressive-disclosure refactor touches the skill entry point and several other references, so keeping it separate makes both reviews easier and avoids expanding #39 beyond its subject.

## Validation

- `git diff --check`
- `uv run --with pyyaml python /home/ryon/.codex/skills/.system/skill-creator/scripts/quick_validate.py skills/jarvus-react`
- searched the edited skill for stale Vite 7.x, unpinned Router installs, commit directives, Claude-specific MCP calls, and exact-path active-state examples
- reviewed all edited relative Markdown links

## Attribution

🤖 This PR was implemented by OpenAI Codex at @ryon's request. Commit `b893ca1` also carries an `OpenAI Codex <codex@openai.com>` co-author trailer.
