### PR TITLE
feat(repo-setup): add skill for standing up a repo the house way

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ npx skills add JarvusInnovations/agent-skills --skill <name>
 npx skills add --global JarvusInnovations/agent-skills --skill <name>
 ```
 
+- [`repo-setup`](skills/repo-setup/README.md) — Stand up a new repo the house way: `develop` as default, `main` as release target, merge-commit-only policy, the branch rulesets that keep auto-delete from eating `develop`, and the Release-PR workflows. You reach for it *before* a repo exists — and to audit existing ones against house conventions.
 - [`ci-quality-gates`](skills/ci-quality-gates/README.md) — Stand up the pre-merge CI quality gates: asdf provisioning + caching, the `lint`/`format:check`/`typecheck`/`test` script contract, and the house linters (oxlint + oxfmt, ruff, tofu fmt/validate). You reach for it to *bootstrap* a repo's CI before code lands on develop.
 - [`agent-dev-workflow`](skills/agent-dev-workflow/README.md) — Agent-friendly local dev: a `bin/` task-runner, worktree-isolated Postgres databases + ports, and a dedicated test DB. You reach for it to *bootstrap* a project's dev workflow.
 - [`release-flow`](skills/release-flow/README.md) — Cut releases via the develop→main Release-PR automation (infra-components `release-prepare`/`validate`/`publish`). *Ambient* across the many repos Jarvus ships, most of which won't have it installed locally.

--- a/skills/repo-setup/README.md
+++ b/skills/repo-setup/README.md
@@ -1,0 +1,48 @@
+# repo-setup
+
+Stands up a new Jarvus repository the house way: `develop` as the default branch, `main` as the
+release target, merge-commit-only merge policy, branch rulesets, and the
+`JarvusInnovations/infra-components` Release-PR workflows. The scope is the repo *shell* — the
+plumbing that the code, the CI gates, and the release flow all sit inside.
+
+## When you'd want it
+
+Creating a new repo, pushing an existing local project to GitHub for the first time, adopting the
+develop→main release flow somewhere it's missing, or auditing an existing repo against house
+conventions.
+
+It also earns its keep when the branch plumbing misbehaves in ways whose cause isn't obvious:
+`develop` disappearing after a release merges, a Release PR reporting "No commits between main and
+develop", PR checks stuck at `action_required` on a brand-new repo, or a first npm publish failing
+from CI.
+
+The reason this is a skill and not a remembered checklist: `gh repo create` ships defaults that are
+wrong for this flow, and two of them stay invisible until they bite. Auto-delete plus a missing
+`deletion` ruleset **deletes your `develop` branch** the first time a release merges. Squash-merging
+left enabled means `git branch --merged` can never again tell you what shipped.
+
+## Install
+
+**Recommended scope: global.** Repo creation is inherently something you do *before* a repo exists
+to install a skill into, and auditing an existing repo's settings is ambient work across the whole
+portfolio.
+
+```bash
+npx skills add --global JarvusInnovations/agent-skills --skill repo-setup
+```
+
+Then say "set up a new repo" or "make this repo standard" and the skill takes over.
+
+## What's inside
+
+- `SKILL.md` — the house shape, the bootstrap procedure, verification, and the new-repo gotchas
+- `references/npm.md` — npm-published packages: `package.json` fields, the publish workflow, the
+  manual-first-publish and trusted-publishing bootstrap, and how to verify a package before it ships
+
+## Related skills
+
+- **`release-flow`** — cutting releases once the repo is wired: the Release PR, changelog, version
+  bump, and merging to publish. `repo-setup` installs the plumbing; `release-flow` operates it.
+- **`ci-quality-gates`** — the lint / format / type-check / test gates that run before merge.
+- **`axi-skills`** — packaging an AXI CLI inside a skill, when the tool ships that way instead of to
+  a registry.

--- a/skills/repo-setup/SKILL.md
+++ b/skills/repo-setup/SKILL.md
@@ -1,0 +1,247 @@
+---
+name: repo-setup
+description: >-
+  Stand up a new Jarvus repository the house way — the one-time bootstrap that wires
+  `develop` as the default branch, `main` as the release target, merge-commit-only merge
+  policy, branch rulesets that keep auto-delete from eating `develop`, and the
+  `JarvusInnovations/infra-components` Release-PR workflows. Use when creating a new repo,
+  running `gh repo create`, pushing an existing local project to GitHub for the first time,
+  adopting the develop→main release flow in a repo that lacks it, or auditing an existing
+  repo against house conventions. Also use when something in the branch/merge plumbing
+  misbehaves: `develop` vanished after a release merged, a release PR reports "No commits
+  between main and develop", PR checks sit at `action_required` on a new repo, someone
+  squash-merged, or a first npm publish fails from CI. Triggers: "new repo", "create a
+  repo", "set up a repo", "gh repo create", "push this to GitHub", "repo settings", "branch
+  protection", "rulesets", "default branch", "develop branch is gone", "set up the release
+  flow", "make this repo standard". Scope is the repo shell — cutting releases belongs to
+  `release-flow`, pre-merge lint/test gates to `ci-quality-gates`.
+---
+
+# Repo setup (Jarvus house shape)
+
+The one-time bootstrap that turns a directory into a Jarvus repo: branches, merge
+policy, protection rulesets, and the Release-PR automation. Everything here is
+**settings and plumbing** — the shell that the code, the CI gates, and the release
+flow all sit inside.
+
+The reason this is a skill rather than a checklist someone remembers: `gh repo create`
+ships defaults that are actively wrong for this flow, and two of the mistakes are
+invisible until they bite weeks later — one silently deletes your `develop` branch,
+the other lets someone squash-merge and break `git branch --merged` forever.
+
+## Scope: what's in, what's out
+
+| In scope (the repo shell) | Out of scope (hand off) |
+| --- | --- |
+| Branches: `develop` default, `main` release target | Cutting a release, changelog, version bump → **`release-flow`** |
+| Merge policy + auto-delete + rulesets | Lint / format / type-check / test gates → **`ci-quality-gates`** |
+| Wiring the Release-PR workflows | Stack scaffolding → **`jarvus-react`**, **`jarvus-fastify`**, **`jarvus-flutter`**, **`jarvus-dbt`** |
+| First-publish bootstrap (npm, etc.) | Bundling an AXI CLI into a skill → **`axi-skills`** |
+
+One-sentence charter: **how a repo is shaped before any code matters.** Once the
+shell is right, the other skills fill it in.
+
+## The house shape
+
+**`develop` is the default branch.** All pushes and PR merges land on `develop`.
+`main` exists only as the release target — the `develop → main` Release PR is the
+sole thing that ever writes to it, and merging that PR is what publishes.
+
+Making `develop` the default is not cosmetic. GitHub bases new PRs on the default
+branch, so a `main` default silently points every feature PR at the release branch,
+where it either bypasses the release flow or gets caught in review. Setting the
+default correctly makes the right thing the lazy thing.
+
+**Merge commits only.** Squash and rebase merges are disabled everywhere:
+
+- **Squash** rewrites a branch's commits into a new commit, so branch tips never
+  become ancestors of the target. `git branch --merged` then can't tell what
+  actually shipped, permanently.
+- **Rebase** has the same ancestry problem.
+- **Merge commits** keep history honest and let the Release-PR changelog attribute
+  commits to their authors.
+
+**Auto-delete head branches is on**, which is where the trap lives — see below.
+
+## The trap that costs you `develop`
+
+`delete_branch_on_merge` deletes the head branch of *any* merged PR. The Release PR's
+head branch is **`develop`**. So the first time a release merges, GitHub deletes
+`develop` — and since `release-prepare` triggers on pushes to `develop`, the release
+flow is now broken with no obvious cause.
+
+What prevents it in every healthy Jarvus repo is a **ruleset with a `deletion` rule**
+on `develop`. Auto-delete respects it and skips the branch. This is the single most
+important thing on this page: **the rulesets aren't optional hardening, they're what
+makes auto-delete safe to leave on.**
+
+Both branches get the same two rules:
+
+- `deletion` — blocks deletion, including by auto-delete
+- `non_fast_forward` — blocks force-pushes that would rewrite shared history
+
+## Procedure
+
+Run these steps yourself rather than handing the user a checklist — the settings are
+tedious, order-dependent, and the ruleset step is precisely the one a human skips.
+Two things are worth stopping for, because they're outward-facing and hard to undo:
+**creating the repo** (org and visibility) and **publishing an artifact**. Confirm
+those, then execute the rest.
+
+### 1. Decide the org and visibility
+
+Published tooling lives under **`JarvusInnovations`** and is public unless there's a
+reason otherwise. Confirm with the user before creating anything — a repo in a company
+org is outward-facing and awkward to undo. If the project is personal rather than
+Jarvus work, that's a different account and worth asking about explicitly.
+
+### 2. Seed the branches
+
+Commit locally first, then create the repo. Seed `main` with the initial commit and do
+the substantive work on `develop`, so the first Release PR has real content:
+
+```sh
+git init && git add <files> && git commit -m "chore: initial commit"
+gh repo create JarvusInnovations/<name> --public --source=. --remote=origin \
+  --description "<one-liner>"
+git push -u origin main
+git checkout -b develop && git push -u origin develop
+gh api -X PATCH repos/JarvusInnovations/<name> -f default_branch=develop
+```
+
+If `main` and `develop` end up at the *same* commit, the first `release-prepare` run
+fails with **"No commits between main and develop"**. That's benign — it self-heals as
+soon as `develop` gets a commit `main` doesn't have — but it does mean the initial
+import never appears in a changelog. Seeding as above avoids it.
+
+### 3. Fix the repo settings
+
+`gh repo create` allows squash and rebase merges and leaves auto-delete off. All three
+are wrong:
+
+```sh
+gh api -X PATCH repos/JarvusInnovations/<name> \
+  -F allow_squash_merge=false \
+  -F allow_rebase_merge=false \
+  -F allow_merge_commit=true \
+  -F delete_branch_on_merge=true
+```
+
+### 4. Add the protection rulesets
+
+Do this **before** the first release merges, or step 3's auto-delete will take
+`develop` with it:
+
+```sh
+for b in develop main; do
+  gh api -X POST repos/JarvusInnovations/<name>/rulesets --input - <<EOF
+{
+  "name": "Protect $b",
+  "target": "branch",
+  "enforcement": "active",
+  "bypass_actors": [],
+  "conditions": { "ref_name": { "include": ["refs/heads/$b"], "exclude": [] } },
+  "rules": [ { "type": "deletion" }, { "type": "non_fast_forward" } ]
+}
+EOF
+done
+```
+
+**Requiring PRs is the maturity dial.** Adding a `pull_request` rule forces changes
+through review. New projects typically start without it on `develop` so work can move
+fast, and turn it on once the project stabilizes or grows past one or two people. Ask
+which stage the project is at rather than assuming; the answer is a judgment call about
+team size and churn, not a default.
+
+To require PRs on a branch, add `{ "type": "pull_request" }` to that ruleset's rules.
+
+### 5. Pin the toolchain
+
+Tool versions come from `asdf` and a committed `.tool-versions`. Never hand-edit that
+file — the whole point is that `asdf` picks resolvable versions:
+
+```sh
+asdf set <tool> latest   # or a specific version
+asdf install
+```
+
+CI should pin the same versions it declares. Provisioning and caching details are
+`ci-quality-gates`' territory.
+
+### 6. Wire the release workflows
+
+Copy the four workflows from a repo already on the flow (`harvest-axi` and `gws-axi`
+are good references) rather than writing them from scratch — they're thin wrappers
+around `JarvusInnovations/infra-components` actions, and the wrappers carry hard-won
+details:
+
+| Workflow | Trigger |
+| --- | --- |
+| `release-prepare.yml` | push to `develop` — opens/refreshes the Release PR |
+| `release-validate.yml` | PR to `main` — gates title format and tag collision |
+| `release-publish.yml` | Release PR merged — tags and publishes |
+| `<publish>.yml` | GitHub release published — ships the artifact |
+
+`release-publish.yml` uses `secrets.BOT_GITHUB_TOKEN`; the other two use
+`secrets.GITHUB_TOKEN`. Confirm the bot token exists at the org level, or the publish
+step fails only at the moment you most want it to work.
+
+How these behave once running — the changelog comment, the version bump, merging to
+publish — is **`release-flow`**. Don't reimplement that reasoning here.
+
+### 7. Verify before declaring done
+
+Settings are easy to get wrong silently, so read them back:
+
+```sh
+gh api repos/JarvusInnovations/<name> \
+  --jq '"default=\(.default_branch) squash=\(.allow_squash_merge) rebase=\(.allow_rebase_merge) merge=\(.allow_merge_commit) autodel=\(.delete_branch_on_merge)"'
+gh api repos/JarvusInnovations/<name>/rulesets \
+  --jq '.[] | "\(.name): \([.rules[].type]|join(",")) on \(.conditions.ref_name.include|join(","))"'
+```
+
+Expect `default=develop squash=false rebase=false merge=true autodel=true`, and a
+`deletion` rule covering both branches.
+
+## Gotchas that only appear on brand-new repos
+
+**PR checks stuck at `action_required`.** GitHub requires manual approval for workflow
+runs from first-time contributors, and `github-actions[bot]` counts as one on a repo
+with no history. The Release PR's checks sit unapproved with no explanation. Approve
+them once and it stops recurring:
+
+```sh
+gh api -X POST repos/<owner>/<repo>/actions/runs/<run-id>/approve
+```
+
+**The first publish usually can't be automated.** Registries that authenticate CI via
+OIDC generally need the artifact to exist before you can configure trust for it, which
+makes the first publish a manual step. This is registry-specific — see
+`references/npm.md` for how it plays out on npm.
+
+**A red `release-validate` on a non-release PR is expected.** The workflow fires on
+every PR into `main` with no title filter, so a hotfix PR shows a failing "title must
+match" check by design. Don't retitle a non-release PR to appease it.
+
+## Adopting the flow in an existing repo
+
+Same steps, different order of risk. Audit first (step 7's commands work on any repo),
+then fix what's off. Two things to watch:
+
+- **If `develop` doesn't exist yet**, create it from the current default branch before
+  flipping the default, so nobody's in-flight work targets a branch that's about to
+  change meaning.
+- **If the repo already has merged history with squashed commits**, `git branch --merged`
+  is already unreliable for those branches; turning squash off stops the bleeding but
+  doesn't repair the past. Say so rather than implying a clean slate.
+
+## Language-specific setup
+
+The shell above is language-agnostic. Details that only apply to a particular kind of
+project live in `references/`:
+
+- **`references/npm.md`** — npm-published packages: `package.json` fields, the
+  `bin/` → `dist/` layout, the publish workflow, the manual-first-publish and trusted
+  publishing bootstrap, and how to verify a package before it ships.
+
+Read the relevant reference when the project is that kind; skip it otherwise.

--- a/skills/repo-setup/references/npm.md
+++ b/skills/repo-setup/references/npm.md
@@ -1,0 +1,228 @@
+# npm-published packages
+
+Everything specific to a repo that ships a package to npm. The branch/merge/ruleset
+shell in `SKILL.md` applies unchanged; this is what goes *inside* it.
+
+## Contents
+
+- [package.json](#packagejson)
+- [Layout and toolchain](#layout-and-toolchain)
+- [The publish workflow](#the-publish-workflow)
+- [Bootstrapping the first publish](#bootstrapping-the-first-publish)
+- [Verify before you ship](#verify-before-you-ship)
+- [Version stamping](#version-stamping)
+
+## package.json
+
+The fields that matter for a published CLI, and why:
+
+```jsonc
+{
+  "name": "<tool>",
+  "version": "0.1.0",
+  "type": "module",
+  "bin": { "<tool>": "dist/bin/<tool>.js" },
+  "files": ["dist", "LICENSE", "README.md"],
+  "engines": { "node": ">=20" },
+  "publishConfig": { "access": "public" },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/JarvusInnovations/<tool>.git"
+  },
+  "license": "MIT",
+  "keywords": ["<domain>", "cli", "agent"]
+}
+```
+
+- **`files`** is an allowlist. Anything not listed stays out of the tarball — which
+  also means anything the build happens to drop inside a listed directory *does* ship.
+  Build metadata written into `dist/` leaks into the published package for exactly
+  this reason.
+- **`publishConfig.access: public`** is required for an unscoped public package;
+  without it the publish fails on a first publish.
+- **`repository`** drives the npm page's source link and is what provenance
+  attestation ties the package back to.
+
+Set these with `npm pkg set` rather than hand-editing, so the JSON stays valid and
+dependency versions keep being resolved by the package manager:
+
+```sh
+npm pkg set type=module bin.<tool>=dist/bin/<tool>.js publishConfig.access=public
+npm pkg set 'files[0]=dist' 'files[1]=LICENSE' 'files[2]=README.md'
+```
+
+Quote the bracket forms — zsh globs `files[0]=dist` and fails with "no matches found".
+
+## Layout and toolchain
+
+```
+<repo>/
+  bin/<tool>.ts        # entry: imports and calls main()
+  src/                 # implementation
+  test/                # vitest suites
+  dist/bin/<tool>.js   # build output (gitignored, shipped via files)
+```
+
+**bun** is the package manager and dev runner; **vitest** is the test runner. Add
+dependencies with `bun add` / `bun add -d` and commit `bun.lock`.
+
+Scripts settle into a predictable set:
+
+```jsonc
+{
+  "build": "tsc",                    // or a bundler, if the deps require it
+  "check": "tsc --noEmit",
+  "dev": "bun bin/<tool>.ts",
+  "test": "vitest run",
+  "prepublishOnly": "<same as build>"
+}
+```
+
+`dist/` is gitignored — CI builds it before publishing, and `prepublishOnly` covers a
+manual publish from a clean checkout.
+
+**When a dependency forces bundling.** Plain `tsc` output is the default and the right
+starting point. Some dependencies can't survive it: a package that imports a
+subpath without a file extension (`import x from "pkg/thing"`) from a dependency that
+publishes no `exports` map is unresolvable under Node's ESM loader, and the CLI fails
+to *start*. A bundler resolves those specifiers at build time. If you switch to one,
+say why in the README and add a CI step that runs the built artifact under plain
+`node` — otherwise the next person "simplifies" the build and ships something that
+won't boot.
+
+## The publish workflow
+
+Triggered by the GitHub release that `release-publish` creates, so it runs *after* the
+Release PR merges:
+
+```yaml
+name: Publish npm package
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish-npm:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write        # required for OIDC trusted publishing
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          # Node 24 ships npm 11.x, which supports trusted publishing out of the
+          # box. Using it directly sidesteps the broken `npm install -g npm@...`
+          # self-upgrade path on node 22 runners (MODULE_NOT_FOUND:
+          # promise-retry inside @npmcli/arborist).
+          node-version: '24.x'
+          registry-url: 'https://registry.npmjs.org'
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: '1.3.11'
+
+      - name: Resolve release tag
+        run: echo "RELEASE_TAG=${GITHUB_REF_NAME}" >> $GITHUB_ENV
+
+      - name: Set package.json version from tag
+        run: npm version --no-git-tag-version --allow-same-version "${RELEASE_TAG#v}"
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build
+        run: bun run build
+
+      - name: Publish to npm
+        run: npm publish --provenance --access public
+```
+
+Two things worth understanding rather than copying blindly:
+
+- **No `NODE_AUTH_TOKEN` anywhere.** Authentication is OIDC trusted publishing, which
+  is why `id-token: write` is present. If you find yourself adding a token, something
+  upstream is misconfigured.
+- **The version comes from the tag, not the repo.** `npm version` rewrites
+  `package.json` before the build, so the build must read its version from
+  `package.json` — see [Version stamping](#version-stamping).
+
+## Bootstrapping the first publish
+
+**The first publish of a new package name cannot come from CI.** Trusted publishing is
+configured per package from that package's settings page on npmjs.com, and the page
+only exists once the package does. So the ordering is:
+
+1. **Publish once manually** from a clean checkout: `npm publish`
+2. **Configure the trusted publisher** on npmjs.com — the repo and the workflow
+   filename (`publish-npm.yml`)
+3. **Every release after that goes through CI**
+
+This isn't a guess; it's visible in the registry. Existing Jarvus packages show a
+human `_npmUser` on their `0.1.0` and `GitHub Actions` on everything after:
+
+```sh
+npm view <pkg>@0.1.0 _npmUser     # a human maintainer — the manual bootstrap
+npm view <pkg> _npmUser           # GitHub Actions <npm-oidc-no-reply@github.com>
+```
+
+Publishing is effectively irreversible — the name is claimed and unpublish is limited
+to a 72-hour window — so confirm with the user before running it, and never publish
+speculatively to "test" the pipeline.
+
+**Verify the trust config actually works** on the first CI-driven release rather than
+assuming. A successful OIDC publish looks like this:
+
+```sh
+npm view <pkg> _npmUser dist.attestations
+# _npmUser.name: 'GitHub Actions'
+# _npmUser.trustedPublisher: { id: 'github', oidcConfigId: 'oidc:...' }
+# dist.attestations.provenance.predicateType: 'https://slsa.dev/provenance/v1'
+```
+
+A human name in `_npmUser` after a CI release means the publish silently fell back to
+a token, or the release was published by hand.
+
+**Watch for a version collision.** If the manual bootstrap published `0.1.0` and the
+Release PR is still titled `Release: v0.1.0`, merging it tags fine and then fails at
+`npm publish` — the version already exists. `release-validate` won't catch it, because
+it only checks that the *git tag* is free, not the registry. Retitle the Release PR to
+the next version before merging.
+
+## Verify before you ship
+
+Reasoning about a tarball is not the same as inspecting one. Pack it, install it
+somewhere clean, and run it:
+
+```sh
+npm pack --dry-run                     # what's in it?
+npm pack                               # produce the tarball
+mkdir /tmp/pkgtest && cd /tmp/pkgtest
+npm init -y && npm install <path>/<pkg>-<version>.tgz
+./node_modules/.bin/<tool> --version   # does the bin resolve and run?
+```
+
+This catches the things that only appear at package boundaries: a `bin` path that
+doesn't match the built file, a runtime dependency accidentally left in
+`devDependencies`, build artifacts leaking into the tarball, and — for anything with
+a native or DOM-shaped dependency — a module that resolves in the repo but not from a
+consumer's `node_modules`.
+
+Exercise the code path that uses your heaviest dependency, not just `--version`. A CLI
+that starts fine can still fail the moment it touches the one dependency you
+externalized.
+
+## Version stamping
+
+Whatever the CLI prints for `--version` should be exactly `package.json`'s version, and
+should match what siblings print — a bare `1.8.0`, not `1.8.0 (a1b2c3d)`.
+
+Resist stamping in `git describe` output. The publish workflow rewrites
+`package.json` from the release tag before building, so `package.json` is already
+authoritative at publish time; adding `git describe` makes the build depend on
+checkout depth and tag availability in CI, which is a fragility with no upside.
+
+If the build inlines the version into a bundle (via a `define` or similar), keep a
+dev-mode fallback so running from source still works without a build step.


### PR DESCRIPTION
Adds a `repo-setup` skill capturing the one-time repo bootstrap — the plumbing that until now lived in people's heads and got re-derived (or missed) each time.

## Why

The motivating failure is an interaction between two settings that look independent:

- `delete_branch_on_merge` deletes the head branch of **any** merged PR
- the Release PR's head branch **is `develop`**

So the first release silently deletes `develop`, and `release-prepare` — which triggers on pushes to `develop` — stops firing with no obvious cause. What prevents it in every healthy repo is a ruleset with a `deletion` rule. The skill treats those rulesets as load-bearing rather than optional hardening.

`gh repo create` also ships defaults that are wrong for this flow: squash and rebase merges enabled, auto-delete off.

## Scope

Deliberately the repo *shell*. It hands off rather than restating:

| Concern | Owner |
| --- | --- |
| Operating the release flow | `release-flow` |
| Pre-merge lint/test gates | `ci-quality-gates` |
| Stack scaffolding | `jarvus-react` / `jarvus-fastify` / `jarvus-flutter` / `jarvus-dbt` |
| AXI CLI packaging | `axi-skills` |

## Contents

- `SKILL.md` — house shape, bootstrap procedure, verification, and the gotchas that only appear on brand-new repos (first-time-contributor `action_required`, "No commits between main and develop", red `release-validate` on non-release PRs)
- `references/npm.md` — npm-specific: `package.json` fields, publish workflow, the manual-first-publish + trusted-publishing bootstrap, and the pack/install/run ritual for verifying a tarball
- Registered in the top-level README under Global scope

## Provenance

Conventions were verified against the actual fleet rather than recalled — merge settings are identical across all seven repos checked, and `deletion` + `non_fast_forward` rulesets are universal (with requiring PRs on `develop` as the documented maturity dial).

🤖 Generated with [Claude Code](https://claude.com/claude-code)